### PR TITLE
Add support for master binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: [ master ]
     tags:
       - '*'
 
@@ -49,10 +50,33 @@ jobs:
 
     - uses: actions/download-artifact@v2
 
-    - uses: softprops/action-gh-release@v1
+    - if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
       with:
         files: |
           x86_64-apple-darwin/solana-stake-o-matic-x86_64-apple-darwin
           x86_64-unknown-linux-gnu/solana-stake-o-matic-x86_64-unknown-linux-gnu
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - if: startsWith(github.ref, 'refs/heads/master')
+      run: |
+        set -x
+        mkdir master-bin
+        mv x86_64-apple-darwin/* master-bin/
+        mv x86_64-unknown-linux-gnu/* master-bin/
+        cd master-bin
+        git init .
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add *
+        git commit -m "Build artifacts from $GITHUB_SHA" --allow-empty
+
+    - if: startsWith(github.ref, 'refs/heads/master')
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master-bin
+        directory: master-bin
+        force: true
+

--- a/fetch-release.sh
+++ b/fetch-release.sh
@@ -15,7 +15,9 @@ Darwin)
   ;;
 esac
 
-if [[ -n $1 ]]; then
+if [[ $1 = master ]]; then
+  RELEASE_BINARY=https://github.com/solana-labs/stake-o-matic/raw/master-bin/sys-$TARGET
+elif [[ -n $1 ]]; then
   RELEASE_BINARY=https://github.com/solana-labs/stake-o-matic/releases/download/$1/solana-stake-o-matic-$TARGET
 else
   RELEASE_BINARY=https://github.com/solana-labs/stake-o-matic/releases/latest/download/solana-stake-o-matic-$TARGET


### PR DESCRIPTION
It's tedious to have to commit to making a release to get build artifacts.  Add support for `./fetch-release.sh master` 