### PR TITLE
Initial stake-pool v0 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +67,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
+name = "arc-swap"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+
+[[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +91,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
 
 [[package]]
 name = "atty"
@@ -86,9 +147,29 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.2",
+ "instant",
+ "pin-project",
+ "rand 0.8.3",
+ "tokio 1.4.0",
+]
 
 [[package]]
 name = "backtrace"
@@ -106,10 +187,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "base64"
@@ -137,6 +243,30 @@ checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if 0.1.10",
+ "clang-sys",
+ "clap",
+ "env_logger 0.7.1",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.14",
+ "peeking_take_while",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -292,6 +422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,8 +543,28 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "chrono-humanize"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8164ae3089baf04ff71f32aeb70213283dcd236dce8bc976d00b17a458f5f71c"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.5.2",
 ]
 
 [[package]]
@@ -421,6 +589,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
 ]
 
 [[package]]
@@ -456,10 +637,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -476,6 +669,18 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "core_affinity"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a03115cc34fb0d7c321dd154a3914b3ca082ccc5c11d91bf7117dbbe7171f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "num_cpus",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "cpuid-bool"
@@ -540,7 +745,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "lazy_static",
@@ -579,7 +784,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -590,7 +795,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -680,6 +885,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +956,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dlopen"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e80ad39f814a9abe68583cd50a2d45c8a67561c3361ab8da240587dda80937"
+dependencies = [
+ "dlopen_derive",
+ "lazy_static",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dlopen_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f236d9e1b1fbd81cea0f9cbdc8dcc7e8ebcd80e6659cd7cb2ad5f6c05946c581"
+dependencies = [
+ "libc",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +1016,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ed56329d95e524ef98177ad672881bdfe7f22f254eb6ae80deb6fdd2ab20c4"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,16 +1049,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d52ff39419d3e16961ecfb9e32f5042bdaacf9a4cc553d2d688057117bae49b"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log 0.4.14",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime",
- "log",
+ "humantime 2.1.0",
+ "log 0.4.14",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+ "synstructure",
 ]
 
 [[package]]
@@ -808,6 +1134,25 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fast-math"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2465292146cdfc2011350fe3b1c616ac83cf0faeedb33463ba1c332ed8948d66"
+dependencies = [
+ "ieee754",
+]
+
+[[package]]
+name = "fd-lock"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0010f02effd88c702318c5dde0463206be67495d0b4d906ba7c0a8f166cc7f06"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "feature-probe"
@@ -867,7 +1212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -875,6 +1220,12 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -938,6 +1289,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -976,6 +1328,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -983,7 +1336,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1007,7 +1360,7 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "serde",
  "typenum",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1055,6 +1408,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log 0.4.14",
+ "regex",
+]
+
+[[package]]
+name = "goauth"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94101e84ede813c04773b0a43396c01b5a3a9376537dbce1125858ae090ae60"
+dependencies = [
+ "arc-swap 1.2.0",
+ "futures 0.3.13",
+ "log 0.4.14",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "simpl",
+ "smpl_jwt",
+ "time 0.2.26",
+ "tokio 1.4.0",
+]
+
+[[package]]
+name = "goblin"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669cdc3826f69a51d3f8fc3f86de81c2378110254f678b8407977736122057a4"
+dependencies = [
+ "log 0.4.14",
+ "plain",
+ "scroll",
+]
+
+[[package]]
+name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,8 +1485,17 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.5",
  "tracing",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1079,7 +1504,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -1162,13 +1587,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes 1.0.1",
  "http",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -1185,9 +1620,61 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time 0.1.43",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.7",
+ "http",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1199,9 +1686,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.1",
  "http",
- "http-body",
+ "http-body 0.4.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1220,12 +1707,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "futures-util",
- "hyper",
- "log",
+ "hyper 0.14.4",
+ "log 0.4.14",
  "rustls",
  "tokio 1.4.0",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.4",
+ "native-tls",
+ "tokio 1.4.0",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1240,13 +1751,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
+
+[[package]]
+name = "indexed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d480125acf340d6a6e59dab69ae19d6fca3a906e1eade277671272cc8f73794b"
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown",
+ "rayon",
 ]
 
 [[package]]
@@ -1360,16 +1884,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-client-transports"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b6c6ad01c7354d60de493148c30ac8a82b759e22ae678c8705e9b8e0c566a4"
+dependencies = [
+ "derive_more",
+ "futures 0.3.13",
+ "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "jsonrpc-server-utils",
+ "log 0.4.14",
+ "parity-tokio-ipc",
+ "serde",
+ "serde_json",
+ "tokio 0.2.25",
+ "url 1.7.2",
+ "websocket",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
 dependencies = [
  "futures 0.3.13",
- "log",
+ "log 0.4.14",
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-core-client"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac9d56dc729912796637c30f475bbf834594607b27740dfea6e5fa7ba40d1f1"
+dependencies = [
+ "futures 0.3.13",
+ "jsonrpc-client-transports",
+]
+
+[[package]]
+name = "jsonrpc-derive"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68ba7e76e5c7796cfa4d2a30e83986550c34404c6d40551c902ca6f7bd4a137"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "jsonrpc-http-server"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff2303c4f0562afcbd2dae75e3e21815095f8994749a80fbcd365877e44ed64"
+dependencies = [
+ "futures 0.3.13",
+ "hyper 0.13.10",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log 0.4.14",
+ "net2",
+ "parking_lot 0.11.1",
+ "unicase 2.6.0",
+]
+
+[[package]]
+name = "jsonrpc-ipc-server"
+version = "17.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c4cd89e5ea7e7f0884e828fc35bb83591a371b92439675eae28efa66c24a97"
+dependencies = [
+ "futures 0.3.13",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log 0.4.14",
+ "parity-tokio-ipc",
+ "parking_lot 0.11.1",
+ "tower-service",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c48dbebce7a9c88ab272a4db7d6478aa4c6d9596e6c086366e89efc4e9ed89e"
+dependencies = [
+ "futures 0.3.13",
+ "jsonrpc-core",
+ "lazy_static",
+ "log 0.4.14",
+ "parking_lot 0.11.1",
+ "rand 0.7.3",
+ "serde",
+]
+
+[[package]]
+name = "jsonrpc-server-utils"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4207cce738bf713a82525065b750a008f28351324f438f56b33d698ada95bb4"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.13",
+ "globset",
+ "jsonrpc-core",
+ "lazy_static",
+ "log 0.4.14",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "unicase 2.6.0",
+]
+
+[[package]]
+name = "jsonrpc-ws-server"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe06e1385e4a912711703123ba44f735627d666f87e5fec764ad1338ec617dc"
+dependencies = [
+ "futures 0.3.13",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log 0.4.14",
+ "parity-ws",
+ "parking_lot 0.11.1",
+ "slab",
 ]
 
 [[package]]
@@ -1389,6 +2033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,10 +2048,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "libloading"
@@ -1411,6 +2077,18 @@ checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "6.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
+dependencies = [
+ "bindgen",
+ "cc",
+ "glob",
+ "libc",
 ]
 
 [[package]]
@@ -1455,11 +2133,29 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.14",
+]
+
+[[package]]
+name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -1495,7 +2191,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1504,7 +2200,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+]
+
+[[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
 ]
 
 [[package]]
@@ -1520,7 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1535,7 +2240,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log",
+ "log 0.4.14",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -1549,9 +2254,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.14",
  "miow 0.3.7",
  "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log 0.4.14",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log 0.4.14",
+ "mio 0.6.23",
+ "miow 0.3.7",
  "winapi 0.3.9",
 ]
 
@@ -1595,7 +2324,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.14",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1629,12 +2358,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1654,7 +2404,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -1664,7 +2414,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1758,7 +2508,7 @@ version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cc",
  "libc",
  "pkg-config",
@@ -1785,6 +2535,40 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.64",
+]
+
+[[package]]
+name = "parity-tokio-ipc"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7f6c69d7687501b2205fe51ade1d7b8797bb3aa141fe5bf13dd78c0483bc89"
+dependencies = [
+ "futures 0.3.13",
+ "libc",
+ "log 0.4.14",
+ "mio-named-pipes",
+ "miow 0.3.7",
+ "rand 0.7.3",
+ "tokio 0.2.25",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parity-ws"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
+dependencies = [
+ "byteorder",
+ "bytes 0.4.12",
+ "httparse",
+ "log 0.4.14",
+ "mio 0.6.23",
+ "mio-extras",
+ "rand 0.7.3",
+ "sha-1",
+ "slab",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1900,6 +2684,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +2732,12 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
@@ -1951,6 +2753,12 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1998,6 +2806,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.0.1",
+ "prost",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2864,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg 0.1.2",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2026,6 +2892,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -2038,6 +2905,16 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2062,6 +2939,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2076,6 +2968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2097,12 +2998,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "raptorq"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0713b99964ca1c1b7e79bf6f95fa95d2d5eb36cd3600cc85f36e9b78d9243df2"
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque 0.8.0",
  "either",
  "rayon-core",
@@ -2119,6 +3088,15 @@ dependencies = [
  "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2144,6 +3122,17 @@ checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
  "redox_syscall 0.2.5",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+dependencies = [
+ "cc",
+ "libc",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -2184,29 +3173,38 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.1",
+ "hyper 0.14.4",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
+ "log 0.4.14",
+ "mime 0.3.16",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.6",
  "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.4.0",
+ "tokio-native-tls",
  "tokio-rustls",
- "url",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53552c6c49e1e13f1a203ef0080ab3bbef0beb570a528993e83df057a9d9bba1"
 
 [[package]]
 name = "ring"
@@ -2221,6 +3219,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -2267,7 +3275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
  "base64 0.13.0",
- "log",
+ "log 0.4.14",
  "ring",
  "sct",
  "webpki",
@@ -2284,6 +3292,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -2309,6 +3323,26 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
 
 [[package]]
 name = "sct"
@@ -2453,6 +3487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +3530,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "signal-hook"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +3559,12 @@ name = "signature"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+
+[[package]]
+name = "simpl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a30f10c911c0355f80f1c2faa8096efc4a58cdf8590b954d5b395efa071c711"
 
 [[package]]
 name = "slab"
@@ -2524,6 +3586,22 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "smpl_jwt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4370044f8b20f944e05c35d77edd3518e6f21fc4de77e593919f287c6a3f428a"
+dependencies = [
+ "base64 0.13.0",
+ "log 0.4.14",
+ "openssl",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "simpl",
+ "time 0.2.26",
+]
 
 [[package]]
 name = "socket2"
@@ -2561,6 +3639,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-banks-client"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf6a6546983dc95bd0d43464c7036f798dad9270ac58785463e1a133bb35082"
+dependencies = [
+ "bincode",
+ "borsh 0.8.2",
+ "borsh-derive 0.8.2",
+ "futures 0.3.13",
+ "mio 0.7.11",
+ "solana-banks-interface",
+ "solana-program",
+ "solana-sdk",
+ "tarpc",
+ "tokio 1.4.0",
+ "tokio-serde",
+]
+
+[[package]]
+name = "solana-banks-interface"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fe6a05805b4a5455c90063d35ca1a635c1f2b18af8022824e1d13171c4a32a"
+dependencies = [
+ "mio 0.7.11",
+ "serde",
+ "solana-sdk",
+ "tarpc",
+]
+
+[[package]]
+name = "solana-banks-server"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8377d7d0dd749f51537d28e9b1205a25ebc54a0a1f9ad56b0d298e5288ae05"
+dependencies = [
+ "bincode",
+ "futures 0.3.13",
+ "log 0.4.14",
+ "mio 0.7.11",
+ "solana-banks-interface",
+ "solana-metrics",
+ "solana-runtime",
+ "solana-sdk",
+ "tarpc",
+ "tokio 1.4.0",
+ "tokio-serde",
+ "tokio-stream",
+]
+
+[[package]]
+name = "solana-bpf-loader-program"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c222f7585f335b8405c471307c44c8096434117bd36b696c6da46adcf70736"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "curve25519-dalek 3.0.2",
+ "log 0.4.14",
+ "num-derive",
+ "num-traits",
+ "rand_core 0.6.2",
+ "solana-measure",
+ "solana-runtime",
+ "solana-sdk",
+ "solana_rbpf",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-budget-program"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0f330a045f8e3ea1f63fd7e6230716d1c4f8517f3bebc3af1deffe8538f9e9"
+dependencies = [
+ "bincode",
+ "chrono",
+ "log 0.4.14",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
 name = "solana-clap-utils"
 version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,7 +3739,7 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tiny-bip39",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2587,7 +3753,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2602,7 +3768,7 @@ dependencies = [
  "clap",
  "indicatif",
  "jsonrpc-core",
- "log",
+ "log 0.4.14",
  "net2",
  "rayon",
  "reqwest",
@@ -2621,7 +3787,7 @@ dependencies = [
  "thiserror",
  "tokio 1.4.0",
  "tungstenite",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2632,11 +3798,91 @@ checksum = "45764a4e5bff58a67b1483360c4b0e3b6c3d20e5a2549a3de478caa91f0dde50"
 dependencies = [
  "bincode",
  "chrono",
- "log",
+ "log 0.4.14",
  "rand_core 0.6.2",
  "serde",
  "serde_derive",
  "solana-sdk",
+]
+
+[[package]]
+name = "solana-core"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e248525b7583837f92f32ab6dc22c443dfbfbb6f95abe3d4e92ebf016b2614c7"
+dependencies = [
+ "ahash 0.6.3",
+ "base64 0.12.3",
+ "bincode",
+ "blake3",
+ "bs58",
+ "bv",
+ "byteorder",
+ "chrono",
+ "core_affinity",
+ "crossbeam-channel 0.4.4",
+ "ed25519-dalek",
+ "flate2",
+ "fs_extra",
+ "indexmap",
+ "itertools",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-http-server",
+ "jsonrpc-pubsub",
+ "jsonrpc-ws-server",
+ "libc",
+ "log 0.4.14",
+ "lru",
+ "miow 0.2.2",
+ "net2",
+ "num-traits",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rand_core 0.6.2",
+ "raptorq",
+ "rayon",
+ "regex",
+ "retain_mut",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-banks-server",
+ "solana-clap-utils",
+ "solana-client",
+ "solana-faucet",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-ledger",
+ "solana-logger",
+ "solana-measure",
+ "solana-merkle-tree",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-program-test",
+ "solana-rayon-threadlimit",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-storage-bigtable",
+ "solana-streamer",
+ "solana-sys-tuner",
+ "solana-transaction-status",
+ "solana-version",
+ "solana-vote-program",
+ "spl-token 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile",
+ "thiserror",
+ "tokio 0.2.25",
+ "tokio 1.4.0",
+ "tokio-util 0.3.1",
+ "trees",
 ]
 
 [[package]]
@@ -2664,6 +3910,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-download-utils"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff416cfc1489168be75a81e9f4c6286ba57c19ad17afe35d0b6d2bb470dd90"
+dependencies = [
+ "bzip2",
+ "console 0.11.3",
+ "indicatif",
+ "log 0.4.14",
+ "reqwest",
+ "solana-runtime",
+ "solana-sdk",
+ "tar",
+]
+
+[[package]]
 name = "solana-faucet"
 version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,7 +3934,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "clap",
- "log",
+ "log 0.4.14",
  "serde",
  "serde_derive",
  "solana-clap-utils",
@@ -2695,7 +3957,7 @@ dependencies = [
  "bs58",
  "bv",
  "generic-array 0.14.4",
- "log",
+ "log 0.4.14",
  "memmap2",
  "rustc_version",
  "serde",
@@ -2720,14 +3982,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ledger"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37e9b41d139667a4f445a4d818fe8d52069447db6704c838ffaa53337698f78"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "chrono",
+ "chrono-humanize",
+ "crossbeam-channel 0.4.4",
+ "dlopen",
+ "dlopen_derive",
+ "ed25519-dalek",
+ "fs_extra",
+ "futures 0.3.13",
+ "futures-util",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "log 0.4.14",
+ "num_cpus",
+ "prost",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rayon",
+ "reed-solomon-erasure",
+ "rocksdb",
+ "rustc_version",
+ "serde",
+ "serde_bytes",
+ "sha2 0.9.3",
+ "solana-bpf-loader-program",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger",
+ "solana-measure",
+ "solana-merkle-tree",
+ "solana-metrics",
+ "solana-perf",
+ "solana-rayon-threadlimit",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-storage-bigtable",
+ "solana-storage-proto",
+ "solana-transaction-status",
+ "solana-vote-program",
+ "tempfile",
+ "thiserror",
+ "tokio 1.4.0",
+ "tokio-stream",
+ "trees",
+]
+
+[[package]]
 name = "solana-logger"
 version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d75a277c10051df00277b2212c9e51dc8cd44229cf6b356a4adb0dc12533507"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.3",
  "lazy_static",
- "log",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -2738,9 +4055,20 @@ checksum = "8e9a066281d6097977a03e974262c84cdf46c9cd92893361aa308e316600402d"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
- "log",
+ "log 0.4.14",
  "solana-metrics",
  "solana-sdk",
+]
+
+[[package]]
+name = "solana-merkle-tree"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0596c10429ee5e39a095c3918bee6f4115c35ddafc34ed99d8acc25f7736ebcf"
+dependencies = [
+ "fast-math",
+ "matches",
+ "solana-program",
 ]
 
 [[package]]
@@ -2749,10 +4077,10 @@ version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68936764aea4e0eff85e6f28a2d53bd99a922132ddf3e0aba1b39dd756b9b6af"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.3",
  "gethostname",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "reqwest",
  "solana-sdk",
 ]
@@ -2765,7 +4093,7 @@ checksum = "3037a702e2ce020b984dc2b186a63d2900c7c11f165fae03f8b346fcd4410e81"
 dependencies = [
  "bincode",
  "clap",
- "log",
+ "log 0.4.14",
  "nix",
  "rand 0.7.3",
  "serde",
@@ -2775,7 +4103,7 @@ dependencies = [
  "solana-logger",
  "solana-version",
  "tokio 1.4.0",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2784,9 +4112,32 @@ version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96676665fc2703d09892e6a33f11d09e244dd34aad7f7094621ce2cdb5b35824"
 dependencies = [
- "log",
+ "log 0.4.14",
  "reqwest",
  "serde_json",
+]
+
+[[package]]
+name = "solana-perf"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af901d1ec7cd360028828ebd718fbd4cfa1845cf8c84fd5a7d03f07340919725"
+dependencies = [
+ "bincode",
+ "curve25519-dalek 2.1.2",
+ "dlopen",
+ "dlopen_derive",
+ "lazy_static",
+ "log 0.4.14",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "solana-budget-program",
+ "solana-logger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -2805,7 +4156,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "num-derive",
  "num-traits",
  "rand 0.7.3",
@@ -2820,6 +4171,32 @@ dependencies = [
  "solana-logger",
  "solana-sdk-macro",
  "thiserror",
+]
+
+[[package]]
+name = "solana-program-test"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048103289eab32f78ebdadcbf3cb7cb314403b2764d1cfe536ca45d9502a3ced"
+dependencies = [
+ "async-trait",
+ "base64 0.12.3",
+ "bincode",
+ "chrono",
+ "chrono-humanize",
+ "log 0.4.14",
+ "mio 0.7.11",
+ "serde",
+ "serde_derive",
+ "solana-banks-client",
+ "solana-banks-server",
+ "solana-bpf-loader-program",
+ "solana-logger",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-vote-program",
+ "thiserror",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -2842,14 +4219,14 @@ dependencies = [
  "console 0.11.3",
  "dialoguer",
  "hidapi",
- "log",
+ "log 0.4.14",
  "num-derive",
  "num-traits",
  "parking_lot 0.10.2",
  "semver 0.9.0",
  "solana-sdk",
  "thiserror",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2872,8 +4249,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libc",
- "libloading",
- "log",
+ "libloading 0.6.7",
+ "log 0.4.14",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -2923,7 +4300,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libsecp256k1",
- "log",
+ "log 0.4.14",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -2980,13 +4357,17 @@ dependencies = [
 name = "solana-stake-o-matic"
 version = "0.0.0"
 dependencies = [
+ "bincode",
+ "bs58",
  "clap",
- "log",
+ "indicatif",
+ "log 0.4.14",
  "reqwest",
  "semver 0.11.0",
  "serde",
  "serde_json",
  "serde_yaml",
+ "solana-account-decoder",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
@@ -2995,6 +4376,8 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-transaction-status",
+ "solana-validator",
+ "solana-vote-program",
  "spl-stake-pool",
  "thiserror",
 ]
@@ -3006,7 +4389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670504a76a3268855fed634661e78a645540189dcee86449de8152a537dc9bde"
 dependencies = [
  "bincode",
- "log",
+ "log 0.4.14",
  "num-derive",
  "num-traits",
  "rustc_version",
@@ -3019,6 +4402,86 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "thiserror",
+]
+
+[[package]]
+name = "solana-storage-bigtable"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51f56c75d758e249921d3bfe3737536d5520d6fd62f01d424b52a2017900b40"
+dependencies = [
+ "arc-swap 0.4.8",
+ "backoff",
+ "bincode",
+ "bzip2",
+ "enum-iterator",
+ "flate2",
+ "futures 0.3.13",
+ "goauth",
+ "log 0.4.14",
+ "prost",
+ "prost-types",
+ "rand_core 0.6.2",
+ "serde",
+ "serde_derive",
+ "smpl_jwt",
+ "solana-sdk",
+ "solana-storage-proto",
+ "solana-transaction-status",
+ "thiserror",
+ "tonic",
+ "zstd",
+]
+
+[[package]]
+name = "solana-storage-proto"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec64e697c862ee91326eb359be40962e545e5ea7a52a1a35765d0ea60c26d30b"
+dependencies = [
+ "bincode",
+ "bs58",
+ "prost",
+ "serde",
+ "serde_derive",
+ "solana-account-decoder",
+ "solana-sdk",
+ "solana-transaction-status",
+]
+
+[[package]]
+name = "solana-streamer"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50138251618745785a644d99a317bd766a5eff9c9e27a6c6bdd428d265836526"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "nix",
+ "solana-logger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-perf",
+ "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-sys-tuner"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae9581433c483c70e65e1f71133db678d40f53474acf8630c9f54ec08085d05"
+dependencies = [
+ "clap",
+ "libc",
+ "log 0.4.14",
+ "nix",
+ "solana-clap-utils",
+ "solana-logger",
+ "solana-version",
+ "sysctl",
+ "unix_socket2",
+ "users",
 ]
 
 [[package]]
@@ -3047,12 +4510,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-validator"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69865ae02af450adf3be90a03a485eb0474e3e715d009602d5589f6924b272ba"
+dependencies = [
+ "base64 0.12.3",
+ "bincode",
+ "chrono",
+ "clap",
+ "console 0.11.3",
+ "core_affinity",
+ "fd-lock",
+ "indicatif",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-ipc-server",
+ "jsonrpc-server-utils",
+ "libc",
+ "log 0.4.14",
+ "num_cpus",
+ "rand 0.7.3",
+ "serde",
+ "signal-hook",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-client",
+ "solana-core",
+ "solana-download-utils",
+ "solana-faucet",
+ "solana-ledger",
+ "solana-logger",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-version",
+ "solana-vote-program",
+ "symlink",
+]
+
+[[package]]
 name = "solana-version"
 version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac5b33dea06a921c39817f43163d15d3a235ea0941b21e7773cd1dcb1c38d36"
 dependencies = [
- "log",
+ "log 0.4.14",
  "rustc_version",
  "serde",
  "serde_derive",
@@ -3069,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f27e4cb48f565714a008f89c8684c861d3884a2109ab97bffdf905a5767dcc"
 dependencies = [
  "bincode",
- "log",
+ "log 0.4.14",
  "num-derive",
  "num-traits",
  "rustc_version",
@@ -3081,6 +4587,24 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "thiserror",
+]
+
+[[package]]
+name = "solana_rbpf"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e36c51d5aa290416c5dea3c43ac467cb57c0b643184af23e6bdab7434710fb"
+dependencies = [
+ "byteorder",
+ "combine",
+ "goblin",
+ "hash32",
+ "libc",
+ "log 0.4.14",
+ "rand 0.7.3",
+ "scroll",
+ "thiserror",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -3174,10 +4698,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "serde",
+ "serde_derive",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -3238,6 +4820,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0501f0d0c2aa64b419abff97c209f4b82c4e67caa63e8dc5b222ecc1b574cb5c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "failure",
+ "libc",
+ "walkdir",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +4841,38 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tarpc"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e325774dd5b35d979e9f4db2b0f0d7d85dc2ff2b676a3150af56c09eafc14b07"
+dependencies = [
+ "anyhow",
+ "fnv",
+ "futures 0.3.13",
+ "humantime 2.1.0",
+ "log 0.4.14",
+ "pin-project",
+ "rand 0.7.3",
+ "serde",
+ "static_assertions",
+ "tarpc-plugins",
+ "tokio 1.4.0",
+ "tokio-serde",
+ "tokio-util 0.6.5",
+]
+
+[[package]]
+name = "tarpc-plugins"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3240378a22b1195734e085ba71d1d4188d50f034aea82635acc430b7005afb5"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -3330,6 +4957,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.3",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "standback",
+ "syn 1.0.64",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,11 +5053,35 @@ dependencies = [
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.6.23",
+ "mio-named-pipes",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite 0.1.12",
+ "signal-hook-registry",
+ "slab",
+ "tokio-macros 0.2.6",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
  "memchr",
@@ -3400,9 +5089,9 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "signal-hook-registry",
- "tokio-macros",
+ "tokio-macros 1.1.0",
  "winapi 0.3.9",
 ]
 
@@ -3456,7 +5145,18 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log",
+ "log 0.4.14",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -3471,6 +5171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.4.0",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,7 +5189,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -3498,6 +5208,33 @@ dependencies = [
  "rustls",
  "tokio 1.4.0",
  "webpki",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes 1.0.1",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.6",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -3535,7 +5272,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "num_cpus",
  "slab",
  "tokio-executor",
@@ -3554,6 +5291,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
+dependencies = [
+ "futures 0.1.31",
+ "native-tls",
+ "tokio-io",
+]
+
+[[package]]
 name = "tokio-udp"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,7 +5309,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log",
+ "log 0.4.14",
  "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
@@ -3578,12 +5326,26 @@ dependencies = [
  "futures 0.1.31",
  "iovec",
  "libc",
- "log",
+ "log 0.4.14",
  "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.14",
+ "pin-project-lite 0.1.12",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3595,8 +5357,8 @@ dependencies = [
  "bytes 1.0.1",
  "futures-core",
  "futures-sink",
- "log",
- "pin-project-lite",
+ "log 0.4.14",
+ "pin-project-lite 0.2.6",
  "tokio 1.4.0",
 ]
 
@@ -3608,6 +5370,62 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.1",
+ "http",
+ "http-body 0.4.1",
+ "hyper 0.14.4",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio 1.4.0",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util 0.6.5",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "rand 0.8.3",
+ "slab",
+ "tokio 1.4.0",
+ "tokio-stream",
+ "tokio-util 0.6.5",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
@@ -3622,8 +5440,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite",
+ "log 0.4.14",
+ "pin-project-lite 0.2.6",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -3633,6 +5464,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
+name = "trees"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa1821e85be4f56cc5bd08bdbc32c0e26d105c90bed9c637992f6c7f747c180"
+dependencies = [
+ "indexed",
 ]
 
 [[package]]
@@ -3653,13 +5509,19 @@ dependencies = [
  "http",
  "httparse",
  "input_buffer",
- "log",
+ "log 0.4.14",
  "native-tls",
  "rand 0.7.3",
  "sha-1",
- "url",
+ "url 2.2.1",
  "utf-8",
 ]
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -3683,6 +5545,24 @@ dependencies = [
  "crunchy",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3722,10 +5602,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "unix_socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57c6eace16c00eccb98a28e85db3370eab0685bdd5e13831d59e2bcb49a1d8a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
 
 [[package]]
 name = "url"
@@ -3734,9 +5643,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.2.2",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "users"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+dependencies = [
+ "libc",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -3759,9 +5678,21 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
@@ -3780,7 +5711,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -3816,7 +5747,7 @@ checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.64",
@@ -3891,6 +5822,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "websocket"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "hyper 0.10.16",
+ "native-tls",
+ "rand 0.6.5",
+ "tokio-codec",
+ "tokio-io",
+ "tokio-reactor",
+ "tokio-tcp",
+ "tokio-tls",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "websocket-base",
+]
+
+[[package]]
+name = "websocket-base"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374"
+dependencies = [
+ "base64 0.10.1",
+ "bitflags",
+ "byteorder",
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "native-tls",
+ "rand 0.6.5",
+ "sha1",
+ "tokio-codec",
+ "tokio-io",
+ "tokio-tcp",
+ "tokio-tls",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/solana-labs/stake-o-matic"
 version = "0.0.0"
 
 [dependencies]
+bincode = "1.3.1"
+bs58 = "0.3.1"
 clap = "2.33.0"
 log = "0.4.11"
 reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
@@ -17,6 +19,7 @@ semver = "0.11.0"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.62"
 serde_yaml = "0.8.13"
+solana-account-decoder = "1.6.5"
 solana-clap-utils = "1.6.5"
 solana-client = "1.6.5"
 solana-cli-config = "1.6.5"
@@ -29,6 +32,11 @@ thiserror = "1.0.21"
 
 spl-stake-pool = { git = "https://github.com/solana-labs/solana-program-library", rev = "938dd01e9b6ca60a184abad359a9385abf0ffbfa" }
 #spl-stake-pool = { path = "../spl/stake-pool/program" }
+
+[dev-dependencies]
+indicatif = "0.15.0"
+solana-validator = "1.6.5"
+solana-vote-program = "1.6.5"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -46,13 +46,14 @@ solana-client = { path = "$solana_dir/client"}
 solana-core = { path = "$solana_dir/core"}
 solana-logger = {path = "$solana_dir/logger" }
 solana-notifier = { path = "$solana_dir/notifier" }
-solana-remote-wallet = {path = "$solana_dir/remote-wallet" }
 solana-program = { path = "$solana_dir/sdk/program" }
 solana-program-test = { path = "$solana_dir/program-test" }
+solana-remote-wallet = {path = "$solana_dir/remote-wallet" }
 solana-runtime = { path = "$solana_dir/runtime" }
 solana-sdk = { path = "$solana_dir/sdk" }
 solana-stake-program = { path = "$solana_dir/programs/stake" }
 solana-transaction-status = { path = "$solana_dir/transaction-status" }
+solana-validator = { path = "$solana_dir/validator" }
 solana-vote-program = { path = "$solana_dir/programs/vote" }
 PATCH
   fi

--- a/src/generic_stake_pool.rs
+++ b/src/generic_stake_pool.rs
@@ -4,13 +4,14 @@ use {
     std::error,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ValidatorStakeState {
     None,     // Validator should receive no stake
     Baseline, // Validator has been awarded a baseline stake
     Bonus,    // Validator has been awarded a bonus stake in addition to the baseline stake
 }
 
+#[derive(Debug, Clone)]
 pub struct ValidatorStake {
     pub identity: Pubkey,
     pub vote_address: Pubkey,

--- a/src/stake_pool_v0.rs
+++ b/src/stake_pool_v0.rs
@@ -1,0 +1,1033 @@
+use {
+    crate::{generic_stake_pool::*, rpc_client_utils::send_and_confirm_transactions},
+    log::*,
+    solana_client::{
+        rpc_client::RpcClient,
+        rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+        rpc_filter,
+        rpc_response::StakeActivationState,
+    },
+    solana_sdk::{
+        account::Account,
+        native_token::{Sol, LAMPORTS_PER_SOL},
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    solana_stake_program::{stake_instruction, stake_state::StakeState},
+    std::{collections::HashSet, error},
+};
+
+// Minimum amount of lamports in a stake pool account
+const MIN_STAKE_ACCOUNT_BALANCE: u64 = LAMPORTS_PER_SOL;
+
+// Don't bother adjusting stake if less than this amount of lamports will be affected
+// (must be >= MIN_STAKE_ACCOUNT_BALANCE)
+const MIN_STAKE_CHANGE_AMOUNT: u64 = MIN_STAKE_ACCOUNT_BALANCE;
+
+#[derive(Debug, Default)]
+pub struct StakePool {
+    baseline_stake_amount: u64,
+    reserve_stake_address: Pubkey,
+    validator_list: HashSet<Pubkey>,
+}
+
+pub fn new(
+    _rpc_client: &RpcClient,
+    baseline_stake_amount: u64,
+    reserve_stake_address: Pubkey,
+    validator_list: HashSet<Pubkey>,
+) -> Result<StakePool, Box<dyn error::Error>> {
+    if baseline_stake_amount < MIN_STAKE_CHANGE_AMOUNT {
+        return Err(format!(
+            "baseline stake amount too small: {}",
+            Sol(baseline_stake_amount)
+        )
+        .into());
+    }
+    Ok(StakePool {
+        baseline_stake_amount,
+        reserve_stake_address,
+        validator_list,
+    })
+}
+
+fn validator_stake_address_seed(vote_address: Pubkey) -> String {
+    format!("S{}", vote_address)[..32].to_string()
+}
+
+fn validator_transient_stake_address_seed(vote_address: Pubkey) -> String {
+    format!("T{}", vote_address)[..32].to_string()
+}
+
+fn validator_stake_address(authorized_staker: Pubkey, vote_address: Pubkey) -> Pubkey {
+    Pubkey::create_with_seed(
+        &authorized_staker,
+        &validator_stake_address_seed(vote_address),
+        &solana_stake_program::id(),
+    )
+    .unwrap()
+}
+
+fn validator_transient_stake_address(authorized_staker: Pubkey, vote_address: Pubkey) -> Pubkey {
+    Pubkey::create_with_seed(
+        &authorized_staker,
+        &validator_transient_stake_address_seed(vote_address),
+        &solana_stake_program::id(),
+    )
+    .unwrap()
+}
+
+impl GenericStakePool for StakePool {
+    fn is_enrolled(&self, validator_identity: &Pubkey) -> bool {
+        self.validator_list.contains(validator_identity)
+    }
+
+    fn apply(
+        &mut self,
+        rpc_client: &RpcClient,
+        dry_run: bool,
+        authorized_staker: &Keypair,
+        desired_validator_stake: &[ValidatorStake],
+    ) -> Result<Vec<String>, Box<dyn error::Error>> {
+        if dry_run {
+            return Err("dryrun not supported".into());
+        }
+
+        let mut inuse_stake_addresses = HashSet::new();
+        inuse_stake_addresses.insert(self.reserve_stake_address);
+
+        let mut min_stake_node_count = 0;
+        let mut bonus_stake_node_count = 0;
+        let mut baseline_stake_node_count = 0;
+
+        for ValidatorStake {
+            vote_address,
+            stake_state,
+            ..
+        } in desired_validator_stake
+        {
+            let stake_address = validator_stake_address(authorized_staker.pubkey(), *vote_address);
+            let transient_stake_address =
+                validator_transient_stake_address(authorized_staker.pubkey(), *vote_address);
+
+            inuse_stake_addresses.insert(stake_address);
+            inuse_stake_addresses.insert(transient_stake_address);
+
+            match stake_state {
+                ValidatorStakeState::None => min_stake_node_count += 1,
+                ValidatorStakeState::Bonus => bonus_stake_node_count += 1,
+                ValidatorStakeState::Baseline => baseline_stake_node_count += 1,
+            }
+        }
+
+        let (all_stake_addresses, all_stake_total_amount) =
+            get_all_stake(rpc_client, authorized_staker.pubkey())?;
+
+        // Merge orphaned stake into the reserve
+        merge_orphaned_stake_accounts(
+            rpc_client,
+            authorized_staker,
+            &all_stake_addresses - &inuse_stake_addresses,
+            self.reserve_stake_address,
+        )?;
+
+        // Merge transient stake back into either the reserve or validator stake
+        let mut busy_validators = HashSet::new();
+        merge_transient_stake_accounts(
+            rpc_client,
+            authorized_staker,
+            desired_validator_stake,
+            self.reserve_stake_address,
+            &mut busy_validators,
+        )?;
+
+        // Create validator stake accounts if needed
+        create_validator_stake_accounts(
+            rpc_client,
+            authorized_staker,
+            desired_validator_stake,
+            self.reserve_stake_address,
+            &mut busy_validators,
+        )?;
+
+        // `total_stake_amount` excludes the `MIN_STAKE_ACCOUNT_BALANCE` that always remains in the reserve account
+        let total_stake_amount = all_stake_total_amount - MIN_STAKE_ACCOUNT_BALANCE;
+
+        info!("Total stake pool balance: {}", Sol(total_stake_amount));
+
+        let total_min_stake_amount = min_stake_node_count * MIN_STAKE_ACCOUNT_BALANCE;
+        info!("Min node count: {}", min_stake_node_count);
+        info!("Min stake amount: {}", Sol(total_min_stake_amount));
+
+        let total_baseline_stake_amount = baseline_stake_node_count * self.baseline_stake_amount;
+        info!("Baseline node count: {}", baseline_stake_node_count);
+        info!("Baseline stake amount: {}", Sol(self.baseline_stake_amount));
+        info!(
+            "Total baseline stake amount: {}",
+            Sol(total_baseline_stake_amount)
+        );
+
+        if total_stake_amount < total_baseline_stake_amount {
+            return Err("Not enough stake to cover the baseline".into());
+        }
+
+        info!("Bonus node count: {}", bonus_stake_node_count);
+        let total_bonus_stake_amount =
+            total_stake_amount.saturating_sub(total_min_stake_amount + total_baseline_stake_amount);
+        info!(
+            "Total bonus stake amount: {}",
+            Sol(total_bonus_stake_amount)
+        );
+
+        let bonus_stake_amount = if bonus_stake_node_count == 0 {
+            0
+        } else {
+            total_bonus_stake_amount / (bonus_stake_node_count as u64)
+        };
+
+        info!("Bonus stake amount: {}", Sol(bonus_stake_amount));
+
+        let notifications = distribute_validator_stake(
+            rpc_client,
+            authorized_staker,
+            desired_validator_stake
+                .iter()
+                .filter(|vs| !busy_validators.contains(&vs.identity))
+                .cloned(),
+            self.reserve_stake_address,
+            self.baseline_stake_amount,
+            bonus_stake_amount,
+        )?;
+        Ok(notifications)
+    }
+}
+
+// Get the balance of a stake account excluding `MIN_STAKE_ACCOUNT_BALANCE`
+fn get_available_stake_balance(
+    rpc_client: &RpcClient,
+    stake_address: Pubkey,
+) -> Result<u64, Box<dyn error::Error>> {
+    let balance = rpc_client.get_balance(&stake_address).map_err(|err| {
+        format!(
+            "Unable to get stake account balance: {}: {}",
+            stake_address, err
+        )
+    })?;
+    if balance < MIN_STAKE_ACCOUNT_BALANCE {
+        Err(format!(
+            "Stake account {} balance too low, {}. Minimum is {}",
+            stake_address,
+            Sol(balance),
+            Sol(MIN_STAKE_ACCOUNT_BALANCE)
+        )
+        .into())
+    } else {
+        Ok(balance - MIN_STAKE_ACCOUNT_BALANCE)
+    }
+}
+
+fn get_all_stake(
+    rpc_client: &RpcClient,
+    authorized_staker: Pubkey,
+) -> Result<(HashSet<Pubkey>, u64), Box<dyn error::Error>> {
+    let mut all_stake_addresses = HashSet::new();
+    let mut total_stake_balance = 0;
+
+    let all_stake_accounts = rpc_client.get_program_accounts_with_config(
+        &solana_stake_program::id(),
+        RpcProgramAccountsConfig {
+            filters: Some(vec![
+                // Filter by `Meta::authorized::staker`, which begins at byte offset 12
+                rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
+                    offset: 12,
+                    bytes: rpc_filter::MemcmpEncodedBytes::Binary(authorized_staker.to_string()),
+                    encoding: Some(rpc_filter::MemcmpEncoding::Binary),
+                }),
+            ]),
+            account_config: RpcAccountInfoConfig {
+                encoding: Some(solana_account_decoder::UiAccountEncoding::Base64),
+                commitment: Some(rpc_client.commitment()),
+                ..RpcAccountInfoConfig::default()
+            },
+        },
+    )?;
+
+    for (address, account) in all_stake_accounts {
+        all_stake_addresses.insert(address);
+        total_stake_balance += account.lamports;
+    }
+
+    Ok((all_stake_addresses, total_stake_balance))
+}
+
+fn merge_orphaned_stake_accounts(
+    rpc_client: &RpcClient,
+    authorized_staker: &Keypair,
+    source_stake_addresses: HashSet<Pubkey>,
+    reserve_stake_address: Pubkey,
+) -> Result<(), Box<dyn error::Error>> {
+    let mut transactions = vec![];
+    for stake_address in source_stake_addresses {
+        let stake_activation = rpc_client
+            .get_stake_activation(stake_address, None)
+            .map_err(|err| {
+                format!(
+                    "Unable to get stake activation for {}: {}",
+                    stake_address, err
+                )
+            })?;
+
+        match stake_activation.state {
+            StakeActivationState::Activating | StakeActivationState::Deactivating => {}
+            StakeActivationState::Active => {
+                transactions.push((
+                    Transaction::new_with_payer(
+                        &[stake_instruction::deactivate_stake(
+                            &stake_address,
+                            &authorized_staker.pubkey(),
+                        )],
+                        Some(&authorized_staker.pubkey()),
+                    ),
+                    format!("Deactivating stake {}", stake_address),
+                ));
+            }
+            StakeActivationState::Inactive => {
+                transactions.push((
+                    Transaction::new_with_payer(
+                        &stake_instruction::merge(
+                            &reserve_stake_address,
+                            &stake_address,
+                            &authorized_staker.pubkey(),
+                        ),
+                        Some(&authorized_staker.pubkey()),
+                    ),
+                    format!(
+                        "Merging orphaned stake, {}, into reserve {}",
+                        stake_address, reserve_stake_address
+                    ),
+                ));
+            }
+        }
+    }
+
+    if !send_and_confirm_transactions(
+        rpc_client,
+        false,
+        transactions,
+        authorized_staker,
+        &mut vec![],
+    )? {
+        Err("Failed to merge orphaned stake accounts".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn merge_transient_stake_accounts(
+    rpc_client: &RpcClient,
+    authorized_staker: &Keypair,
+    desired_validator_stake: &[ValidatorStake],
+    reserve_stake_address: Pubkey,
+    busy_validators: &mut HashSet<Pubkey>,
+) -> Result<(), Box<dyn error::Error>> {
+    let mut transactions = vec![];
+    for ValidatorStake {
+        identity,
+        vote_address,
+        ..
+    } in desired_validator_stake
+    {
+        let stake_address = validator_stake_address(authorized_staker.pubkey(), *vote_address);
+        let transient_stake_address =
+            validator_transient_stake_address(authorized_staker.pubkey(), *vote_address);
+
+        let transient_stake_account = rpc_client
+            .get_account_with_commitment(&transient_stake_address, rpc_client.commitment())?
+            .value;
+
+        if let Some(transient_stake_account) = transient_stake_account {
+            let transient_stake_activation = rpc_client
+                .get_stake_activation(transient_stake_address, None)
+                .map_err(|err| {
+                    format!(
+                        "Unable to get activation information for transient stake account: {}: {}",
+                        transient_stake_address, err
+                    )
+                })?;
+
+            match transient_stake_activation.state {
+                StakeActivationState::Activating | StakeActivationState::Deactivating => {
+                    warn!(
+                        "{} busy due to transient stake activation/deactivation",
+                        identity
+                    );
+                    busy_validators.insert(*identity);
+                }
+                StakeActivationState::Active => {
+                    let stake_account = rpc_client
+                        .get_account_with_commitment(&stake_address, rpc_client.commitment())?
+                        .value
+                        .unwrap_or_default();
+
+                    if stake_accounts_have_same_credits_observed(
+                        &stake_account,
+                        &transient_stake_account,
+                    )? {
+                        transactions.push((
+                            Transaction::new_with_payer(
+                                &stake_instruction::merge(
+                                    &stake_address,
+                                    &transient_stake_address,
+                                    &authorized_staker.pubkey(),
+                                ),
+                                Some(&authorized_staker.pubkey()),
+                            ),
+                            format!("Merging active transient stake for {}", identity),
+                        ));
+                    } else {
+                        warn!(
+                                "Unable to merge active transient stake for {} due to credits observed mismatch",
+                                identity
+                            );
+                        busy_validators.insert(*identity);
+                    }
+                }
+                StakeActivationState::Inactive => {
+                    transactions.push((
+                        Transaction::new_with_payer(
+                            &stake_instruction::merge(
+                                &reserve_stake_address,
+                                &transient_stake_address,
+                                &authorized_staker.pubkey(),
+                            ),
+                            Some(&authorized_staker.pubkey()),
+                        ),
+                        format!("Merging inactive transient stake for {}", identity),
+                    ));
+                }
+            }
+        }
+    }
+
+    if !send_and_confirm_transactions(
+        rpc_client,
+        false,
+        transactions,
+        authorized_staker,
+        &mut vec![],
+    )? {
+        Err("Failed to merge transient stake".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn stake_accounts_have_same_credits_observed(
+    stake_account1: &Account,
+    stake_account2: &Account,
+) -> Result<bool, Box<dyn error::Error>> {
+    use solana_stake_program::stake_state::Stake;
+
+    let stake_state1 = bincode::deserialize(stake_account1.data.as_slice())
+        .map_err(|err| format!("Invalid stake account 1: {}", err))?;
+    let stake_state2 = bincode::deserialize(stake_account2.data.as_slice())
+        .map_err(|err| format!("Invalid stake account 2: {}", err))?;
+
+    if let (
+        StakeState::Stake(
+            _,
+            Stake {
+                delegation: _,
+                credits_observed: credits_observed1,
+            },
+        ),
+        StakeState::Stake(
+            _,
+            Stake {
+                delegation: _,
+                credits_observed: credits_observed2,
+            },
+        ),
+    ) = (stake_state1, stake_state2)
+    {
+        return Ok(credits_observed1 == credits_observed2);
+    }
+    Ok(false)
+}
+
+fn create_validator_stake_accounts(
+    rpc_client: &RpcClient,
+    authorized_staker: &Keypair,
+    desired_validator_stake: &[ValidatorStake],
+    reserve_stake_address: Pubkey,
+    busy_validators: &mut HashSet<Pubkey>,
+) -> Result<(), Box<dyn error::Error>> {
+    let mut reserve_stake_balance = get_available_stake_balance(rpc_client, reserve_stake_address)
+        .map_err(|err| {
+            format!(
+                "Unable to get reserve stake account balance: {}: {}",
+                reserve_stake_address, err
+            )
+        })?;
+    info!(
+        "Reserve stake available balance: {}",
+        Sol(reserve_stake_balance)
+    );
+
+    let mut transactions = vec![];
+    for ValidatorStake {
+        identity,
+        vote_address,
+        ..
+    } in desired_validator_stake
+    {
+        let stake_address = validator_stake_address(authorized_staker.pubkey(), *vote_address);
+        let stake_account = rpc_client
+            .get_account_with_commitment(&stake_address, rpc_client.commitment())?
+            .value;
+
+        if stake_account.is_some() {
+            // Check if the stake account is busy
+            let stake_activation = rpc_client
+                .get_stake_activation(stake_address, None)
+                .map_err(|err| {
+                    format!(
+                        "Unable to get activation information for stake account: {}: {}",
+                        stake_address, err
+                    )
+                })?;
+
+            if stake_activation.state != StakeActivationState::Active {
+                warn!("{} busy due to {:?}", identity, stake_activation);
+                busy_validators.insert(*identity);
+            }
+        } else {
+            if reserve_stake_balance < MIN_STAKE_ACCOUNT_BALANCE {
+                // Try again next epoch
+                warn!(
+                    "Insufficient funds in reserve stake account to create stake account: {} required, {} balance",
+                    Sol(MIN_STAKE_ACCOUNT_BALANCE), Sol(reserve_stake_balance)
+                );
+            } else {
+                // Create a stake account for the validator
+                reserve_stake_balance -= MIN_STAKE_ACCOUNT_BALANCE;
+
+                let mut instructions = stake_instruction::split_with_seed(
+                    &reserve_stake_address,
+                    &authorized_staker.pubkey(),
+                    MIN_STAKE_ACCOUNT_BALANCE,
+                    &stake_address,
+                    &authorized_staker.pubkey(),
+                    &validator_stake_address_seed(*vote_address),
+                );
+                instructions.push(stake_instruction::delegate_stake(
+                    &stake_address,
+                    &authorized_staker.pubkey(),
+                    vote_address,
+                ));
+
+                transactions.push((
+                    Transaction::new_with_payer(&instructions, Some(&authorized_staker.pubkey())),
+                    format!(
+                        "Creating stake account for validator {} ({})",
+                        identity, stake_address
+                    ),
+                ));
+            }
+            warn!("{} busy due to no stake account", identity);
+            busy_validators.insert(*identity);
+        }
+    }
+
+    if !send_and_confirm_transactions(
+        rpc_client,
+        false,
+        transactions,
+        authorized_staker,
+        &mut vec![],
+    )? {
+        Err("Failed to create validator stake accounts".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn distribute_validator_stake<V>(
+    rpc_client: &RpcClient,
+    authorized_staker: &Keypair,
+    desired_validator_stake: V,
+    reserve_stake_address: Pubkey,
+    baseline_stake_amount: u64,
+    bonus_stake_amount: u64,
+) -> Result<Vec<String>, Box<dyn error::Error>>
+where
+    V: IntoIterator<Item = ValidatorStake>,
+{
+    let mut reserve_stake_balance = get_available_stake_balance(rpc_client, reserve_stake_address)
+        .map_err(|err| {
+            format!(
+                "Unable to get reserve stake account balance: {}: {}",
+                reserve_stake_address, err
+            )
+        })?;
+
+    info!(
+        "Reserve stake available balance before updates: {}",
+        Sol(reserve_stake_balance)
+    );
+
+    let mut transactions = vec![];
+    for ValidatorStake {
+        identity,
+        stake_state,
+        memo,
+        vote_address,
+    } in desired_validator_stake
+    {
+        let desired_balance = match stake_state {
+            ValidatorStakeState::None => MIN_STAKE_ACCOUNT_BALANCE,
+            ValidatorStakeState::Baseline => baseline_stake_amount,
+            ValidatorStakeState::Bonus => bonus_stake_amount,
+        };
+
+        let stake_address = validator_stake_address(authorized_staker.pubkey(), vote_address);
+        let transient_stake_address =
+            validator_transient_stake_address(authorized_staker.pubkey(), vote_address);
+
+        let balance = rpc_client.get_balance(&stake_address).map_err(|err| {
+            format!(
+                "Unable to get stake account balance: {}: {}",
+                stake_address, err
+            )
+        })?;
+
+        info!(
+            "desired stake for {} ({:?}) is {}, current balance is {}",
+            identity,
+            stake_state,
+            Sol(desired_balance),
+            Sol(balance)
+        );
+
+        let transient_stake_address_seed = validator_transient_stake_address_seed(vote_address);
+
+        #[allow(clippy::comparison_chain)]
+        if balance > desired_balance {
+            let amount_to_remove = balance - desired_balance;
+            if amount_to_remove < MIN_STAKE_CHANGE_AMOUNT {
+                info!(
+                    "Skipping deactivation since amount_to_remove is too small: {}",
+                    Sol(amount_to_remove)
+                );
+            } else {
+                info!("removing {} stake", Sol(amount_to_remove));
+                let mut instructions = stake_instruction::split_with_seed(
+                    &stake_address,
+                    &authorized_staker.pubkey(),
+                    amount_to_remove,
+                    &transient_stake_address,
+                    &authorized_staker.pubkey(),
+                    &transient_stake_address_seed,
+                );
+                instructions.push(stake_instruction::deactivate_stake(
+                    &transient_stake_address,
+                    &authorized_staker.pubkey(),
+                ));
+
+                transactions.push((
+                    Transaction::new_with_payer(&instructions, Some(&authorized_staker.pubkey())),
+                    format!("{}. Removing {} stake", memo, Sol(amount_to_remove)),
+                ));
+            }
+        } else if balance < desired_balance {
+            let mut amount_to_add = desired_balance - balance;
+            if amount_to_add > reserve_stake_balance {
+                info!(
+                    "note: amount_to_add > reserve_stake_balance: {} > {}",
+                    amount_to_add, reserve_stake_balance
+                );
+                amount_to_add = reserve_stake_balance;
+            }
+
+            if amount_to_add < MIN_STAKE_CHANGE_AMOUNT {
+                info!(
+                    "Skipping delegation since amount_to_add is too small: {}",
+                    Sol(amount_to_add)
+                );
+            } else {
+                reserve_stake_balance -= amount_to_add;
+                info!("adding {} stake", Sol(amount_to_add));
+
+                let mut instructions = stake_instruction::split_with_seed(
+                    &reserve_stake_address,
+                    &authorized_staker.pubkey(),
+                    amount_to_add,
+                    &transient_stake_address,
+                    &authorized_staker.pubkey(),
+                    &transient_stake_address_seed,
+                );
+                instructions.push(stake_instruction::delegate_stake(
+                    &transient_stake_address,
+                    &authorized_staker.pubkey(),
+                    &vote_address,
+                ));
+
+                transactions.push((
+                    Transaction::new_with_payer(&instructions, Some(&authorized_staker.pubkey())),
+                    format!("{}. Adding {} stake", memo, Sol(amount_to_add)),
+                ));
+            }
+        }
+    }
+    info!(
+        "Reserve stake available balance after updates: {}",
+        Sol(reserve_stake_balance)
+    );
+
+    let mut notifications = vec![];
+    let ok = send_and_confirm_transactions(
+        rpc_client,
+        false,
+        transactions,
+        authorized_staker,
+        &mut notifications,
+    )?;
+
+    if !ok {
+        error!("One or more transactions failed to execute")
+    }
+    Ok(notifications)
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::rpc_client_utils::test::*,
+        solana_sdk::{
+            clock::Epoch,
+            epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
+            native_token::sol_to_lamports,
+            signature::{Keypair, Signer},
+        },
+        solana_validator::test_validator::*,
+    };
+
+    fn num_stake_accounts(rpc_client: &RpcClient, authorized_staker: &Keypair) -> usize {
+        get_all_stake(&rpc_client, authorized_staker.pubkey())
+            .unwrap()
+            .0
+            .len()
+    }
+
+    fn validator_stake_balance(
+        rpc_client: &RpcClient,
+        authorized_staker: &Keypair,
+        validator: &ValidatorAddressPair,
+    ) -> u64 {
+        let stake_address =
+            validator_stake_address(authorized_staker.pubkey(), validator.vote_address);
+        rpc_client.get_balance(&stake_address).unwrap()
+    }
+
+    fn uniform_stake_pool_apply(
+        stake_pool: &mut StakePool,
+        rpc_client: &RpcClient,
+        authorized_staker: &Keypair,
+        validators: &[ValidatorAddressPair],
+        stake_state: ValidatorStakeState,
+        expected_validator_stake_balance: u64,
+        expected_reserve_stake_balance: u64,
+    ) {
+        let desired_validator_stake = validators
+            .iter()
+            .map(|vap| ValidatorStake {
+                identity: vap.identity,
+                vote_address: vap.vote_address,
+                stake_state,
+                memo: format!("{:?}", stake_state),
+            })
+            .collect::<Vec<_>>();
+
+        stake_pool
+            .apply(
+                rpc_client,
+                false,
+                authorized_staker,
+                &desired_validator_stake,
+            )
+            .unwrap();
+
+        assert_eq!(
+            num_stake_accounts(rpc_client, authorized_staker),
+            1 + 2 * validators.len()
+        );
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        stake_pool
+            .apply(
+                rpc_client,
+                false,
+                authorized_staker,
+                &desired_validator_stake,
+            )
+            .unwrap();
+
+        assert_eq!(
+            num_stake_accounts(rpc_client, authorized_staker),
+            1 + validators.len()
+        );
+        assert_eq!(
+            rpc_client
+                .get_balance(&stake_pool.reserve_stake_address)
+                .unwrap(),
+            expected_reserve_stake_balance
+        );
+        for validator in validators {
+            assert_eq!(
+                validator_stake_balance(rpc_client, authorized_staker, validator),
+                expected_validator_stake_balance
+            );
+        }
+    }
+
+    #[test]
+    fn this_test_is_too_big_and_slow() {
+        solana_logger::setup_with_default("solana_stake_o_matic=info");
+
+        let mut test_validator_genesis = TestValidatorGenesis::default();
+        test_validator_genesis.epoch_schedule(EpochSchedule::custom(
+            MINIMUM_SLOTS_PER_EPOCH,
+            MINIMUM_SLOTS_PER_EPOCH,
+            /* enable_warmup_epochs = */ false,
+        ));
+        let (test_validator, authorized_staker) = test_validator_genesis.start();
+
+        let (rpc_client, _recent_blockhash, _fee_calculator) = test_validator.rpc_client();
+
+        let assert_validator_stake_activation =
+            |vap: &ValidatorAddressPair, epoch: Epoch, state: StakeActivationState| {
+                let stake_address =
+                    validator_stake_address(authorized_staker.pubkey(), vap.vote_address);
+                assert_eq!(
+                    rpc_client
+                        .get_stake_activation(stake_address, Some(epoch))
+                        .unwrap()
+                        .state,
+                    state,
+                );
+            };
+
+        // ===========================================================
+        info!("Create three validators, the reserve stake account, and a stake pool");
+        let validators = create_validators(&rpc_client, &authorized_staker, 3).unwrap();
+
+        let baseline_stake_amount = sol_to_lamports(10.);
+        let total_stake_amount =
+            (baseline_stake_amount + sol_to_lamports(100.)) * validators.len() as u64;
+        let total_stake_amount_plus_min = total_stake_amount + MIN_STAKE_ACCOUNT_BALANCE;
+
+        let reserve_stake_address =
+            create_stake_account(&rpc_client, &authorized_staker, total_stake_amount_plus_min)
+                .unwrap()
+                .pubkey();
+
+        let assert_reserve_account_only = || {
+            assert_eq!(
+                rpc_client.get_balance(&reserve_stake_address).unwrap(),
+                total_stake_amount_plus_min
+            );
+            {
+                assert_eq!(
+                    get_available_stake_balance(&rpc_client, reserve_stake_address).unwrap(),
+                    total_stake_amount
+                );
+
+                let (all_stake, all_stake_total_amount) =
+                    get_all_stake(&rpc_client, authorized_staker.pubkey()).unwrap();
+                assert_eq!(all_stake_total_amount, total_stake_amount_plus_min);
+                assert_eq!(all_stake.len(), 1);
+                assert!(all_stake.contains(&reserve_stake_address));
+            }
+        };
+        assert_reserve_account_only();
+
+        let mut stake_pool = new(
+            &rpc_client,
+            baseline_stake_amount,
+            reserve_stake_address,
+            validators.iter().map(|vap| vap.identity).collect(),
+        )
+        .unwrap();
+
+        // ===========================================================
+        info!("Start with no stake in the validators");
+        let epoch = rpc_client.get_epoch_info().unwrap().epoch;
+        stake_pool
+            .apply(
+                &rpc_client,
+                false,
+                &authorized_staker,
+                &validators
+                    .iter()
+                    .map(|vap| ValidatorStake {
+                        identity: vap.identity,
+                        vote_address: vap.vote_address,
+                        stake_state: ValidatorStakeState::None,
+                        memo: "none".to_string(),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+
+        info!("min: wait for stake activation");
+        assert_eq!(
+            rpc_client
+                .get_balance(&stake_pool.reserve_stake_address)
+                .unwrap(),
+            total_stake_amount_plus_min - MIN_STAKE_ACCOUNT_BALANCE * validators.len() as u64,
+        );
+
+        for validator in &validators {
+            assert_validator_stake_activation(validator, epoch, StakeActivationState::Activating);
+            assert_eq!(
+                validator_stake_balance(&rpc_client, &authorized_staker, validator),
+                MIN_STAKE_ACCOUNT_BALANCE
+            );
+        }
+        assert_eq!(
+            num_stake_accounts(&rpc_client, &authorized_staker),
+            1 + validators.len()
+        );
+        let epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        for validator in &validators {
+            assert_validator_stake_activation(validator, epoch, StakeActivationState::Active);
+        }
+
+        // ===========================================================
+        info!("All validators to baseline stake level");
+        uniform_stake_pool_apply(
+            &mut stake_pool,
+            &rpc_client,
+            &authorized_staker,
+            &validators,
+            ValidatorStakeState::Baseline,
+            baseline_stake_amount,
+            total_stake_amount_plus_min - baseline_stake_amount * validators.len() as u64,
+        );
+
+        // ===========================================================
+        info!("All the validators to bonus stake level");
+        uniform_stake_pool_apply(
+            &mut stake_pool,
+            &rpc_client,
+            &authorized_staker,
+            &validators,
+            ValidatorStakeState::Bonus,
+            total_stake_amount / validators.len() as u64,
+            MIN_STAKE_ACCOUNT_BALANCE,
+        );
+
+        // ===========================================================
+        info!("Different stake for each validator");
+        let desired_validator_stake = vec![
+            ValidatorStake {
+                identity: validators[0].identity,
+                vote_address: validators[0].vote_address,
+                stake_state: ValidatorStakeState::None,
+                memo: "none".to_string(),
+            },
+            ValidatorStake {
+                identity: validators[1].identity,
+                vote_address: validators[1].vote_address,
+                stake_state: ValidatorStakeState::Baseline,
+                memo: "baseline".to_string(),
+            },
+            ValidatorStake {
+                identity: validators[2].identity,
+                vote_address: validators[2].vote_address,
+                stake_state: ValidatorStakeState::Bonus,
+                memo: "bonus".to_string(),
+            },
+        ];
+
+        stake_pool
+            .apply(
+                &rpc_client,
+                false,
+                &authorized_staker,
+                &desired_validator_stake,
+            )
+            .unwrap();
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        stake_pool
+            .apply(
+                &rpc_client,
+                false,
+                &authorized_staker,
+                &desired_validator_stake,
+            )
+            .unwrap();
+
+        // after the first epoch, validators 0 and 1 are at their target levels but validator 2
+        // needs one more epoch for the additional bonus stake to arrive
+        for (validator, expected_sol_balance) in validators.iter().zip(&[1., 10., 110.]) {
+            assert_eq!(
+                sol_to_lamports(*expected_sol_balance),
+                validator_stake_balance(&rpc_client, &authorized_staker, validator),
+                "stake balance mismatch for validator {}, expected {}",
+                validator.identity,
+                expected_sol_balance
+            );
+        }
+
+        assert_eq!(
+            rpc_client
+                .get_balance(&stake_pool.reserve_stake_address)
+                .unwrap(),
+            MIN_STAKE_ACCOUNT_BALANCE,
+        );
+
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        stake_pool
+            .apply(
+                &rpc_client,
+                false,
+                &authorized_staker,
+                &desired_validator_stake,
+            )
+            .unwrap();
+
+        assert_eq!(
+            rpc_client
+                .get_balance(&stake_pool.reserve_stake_address)
+                .unwrap(),
+            MIN_STAKE_ACCOUNT_BALANCE,
+        );
+
+        // after the second epoch, validator 2 is now has all the bonus stake
+        for (validator, expected_sol_balance) in validators.iter().zip(&[1., 10., 319.]) {
+            assert_eq!(
+                sol_to_lamports(*expected_sol_balance),
+                validator_stake_balance(&rpc_client, &authorized_staker, validator),
+                "stake balance mismatch for validator {}",
+                validator.identity
+            );
+        }
+
+        // ===========================================================
+        info!("remove all validators");
+
+        // deactivate all validator stake
+        stake_pool
+            .apply(&rpc_client, false, &authorized_staker, &[])
+            .unwrap();
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        // merge deactivated validator stake back into the reserve
+        stake_pool
+            .apply(&rpc_client, false, &authorized_staker, &[])
+            .unwrap();
+        // all stake has returned to the reserve account
+        assert_reserve_account_only();
+    }
+}

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -35,6 +35,8 @@ crates=(
   solana-sdk
   solana-stake-program
   solana-transaction-status
+  solana-validator
+  solana-vote-program
 )
 
 set -x


### PR DESCRIPTION
This PR adds a v0 stake pool implementation that's based on local stake split/merge operations, but conceptually behaves the  same way that the SPL Stake Pool program that @joncinque is hacking on.

There exists a reserve stake account that always will have >= 1 SOL in it.  Each validator in the pool has two stake accounts:
1. Their main stake account that is always active with >= 1 SOL in it
2. A transient stake account that is used to move stake between the reserve stake account and the validator's main account.

The single transient stake for each validator may either be activating to deactivating.  

This pool attempts to aggressively keep the reserve stake account balance at 1 SOL, so the bonus stake amount is variable based on the number of validators that are current.   The baseline stake amount is fixed.  As an example, if one validator goes delinquent then all stake from that validator will be redistributed as bonus to the remaining validators eligible for a bonus.   This means that when that validator recovers, it won't receive the baseline stake back as quickly because first the pool must first scavenge the baseline stake from everybody's bonus.

Most of this v0 implementation goes away when the SPL Stake Pool is integrated.