### PR TITLE
Add plumbing to link testnet participation with mainnet stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,6 +4422,7 @@ dependencies = [
  "clap",
  "indicatif",
  "log 0.4.14",
+ "regex",
  "reqwest",
  "semver 0.11.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 clap = "2.33.0"
 log = "0.4.11"
+regex = "1.3.9"
 reqwest = { version = "0.11.3", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 semver = "0.11.0"
 serde = { version = "1.0.126", features = ["derive"] }

--- a/src/generic_stake_pool.rs
+++ b/src/generic_stake_pool.rs
@@ -12,6 +12,12 @@ pub enum ValidatorStakeState {
     Bonus,    // Validator has earned the bonus stake level
 }
 
+impl Default for ValidatorStakeState {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ValidatorStake {
     pub identity: Pubkey,


### PR DESCRIPTION
New knobs:
```
        --enforce-testnet-participation    Enforce the minimum testnet participation requirement.
        --min-testnet-participation <N M>...
            Require that the participant's mainnet-beta validator be staked for N out of the last N epochs to be
            delegable for mainnet-beta stake.
            This setting is ignored if the --cluster is not `mainnet-beta`
```

Coming soon: the missing registration piece to link testnet/mainnet validators to a participant
