### PR TITLE
Prioritize funding smaller stake accounts

### DIFF
--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -765,12 +765,29 @@ where
         Sol(reserve_stake_balance)
     );
 
+    // Prioritize funding smaller stake accounts to maximize the number of accounts that will be
+    // funded with the available reserve stake.
+    let mut min_stake = vec![];
+    let mut baseline_stake = vec![];
+    let mut bonus_stake = vec![];
+
+    for validator_stake in desired_validator_stake {
+        match validator_stake.stake_state {
+            ValidatorStakeState::None => min_stake.push(validator_stake),
+            ValidatorStakeState::Baseline => baseline_stake.push(validator_stake),
+            ValidatorStakeState::Bonus => bonus_stake.push(validator_stake),
+        };
+    }
+
     let mut transactions = vec![];
     for ValidatorStake {
         identity,
         stake_state,
         vote_address,
-    } in desired_validator_stake
+    } in min_stake
+        .into_iter()
+        .chain(baseline_stake)
+        .chain(bonus_stake)
     {
         let desired_balance = match stake_state {
             ValidatorStakeState::None => 0,

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -575,12 +575,29 @@ where
         Sol(reserve_stake_balance)
     );
 
+    // Prioritize funding smaller stake accounts to maximize the number of accounts that will be
+    // funded with the available reserve stake.
+    let mut min_stake = vec![];
+    let mut baseline_stake = vec![];
+    let mut bonus_stake = vec![];
+
+    for validator_stake in desired_validator_stake {
+        match validator_stake.stake_state {
+            ValidatorStakeState::None => min_stake.push(validator_stake),
+            ValidatorStakeState::Baseline => baseline_stake.push(validator_stake),
+            ValidatorStakeState::Bonus => bonus_stake.push(validator_stake),
+        };
+    }
+
     let mut transactions = vec![];
     for ValidatorStake {
         identity,
         stake_state,
         vote_address,
-    } in desired_validator_stake
+    } in min_stake
+        .into_iter()
+        .chain(baseline_stake)
+        .chain(bonus_stake)
     {
         let desired_balance = match stake_state {
             ValidatorStakeState::None => MIN_STAKE_ACCOUNT_BALANCE,


### PR DESCRIPTION
Prioritize funding smaller stake accounts to maximize the number of accounts that will be funded with the available reserve stake.

As observed on testnet, [this](https://github.com/solana-labs/stake-o-matic/wiki/Validator-4UNcH9sxWUo6bfZY93gmPiGZNssEgmG9Ho7C9ecjMv5N) validator has missed out on their baseline stake for two epochs now because some bonus nodes keep getting funded before it and the reserve stake balance is emptied.  IMO it's preferable that validators get from 0 stake to baseline stake, than validators with bonus stake receive more bonus