### PR TITLE
Enable notifications from follower builds

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1643,7 +1643,6 @@ fn main() -> BoxResult<()> {
     if first_time {
         EpochClassification::new(epoch_classification).save(epoch, &config.cluster_db_path())?;
         generate_markdown(epoch, &config)?;
-
     }
 
     if post_notifications {


### PR DESCRIPTION
**Problem**
Logic for making first-in-the-epoch classifications is lumped in with whether or not to push notifications.  This prevents follower builds from pushing notifications from existing classifications.

**Solution**
Break out the booleans.