### PR TITLE
Extend ValidatorClassification and EpochClassificationV1 structs to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,9 @@ name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -18,7 +18,7 @@ clap = "2.33.0"
 log = "0.4.11"
 regex = "1.5.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["blocking", "rustls-tls", "json"] }
-semver = "1.0.3"
+semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.62"
 serde_yaml = "0.8.13"

--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -1,3 +1,4 @@
+use crate::InfrastructureConcentrationAffects;
 use {
     crate::{
         data_center_info::{DataCenterId, DataCenterInfo},
@@ -6,7 +7,6 @@ use {
     log::*,
     semver::Version,
     serde::{Deserialize, Serialize},
-    serde_yaml::{Mapping, Value},
     solana_sdk::{clock::Epoch, pubkey::Pubkey},
     std::{
         collections::HashMap,
@@ -103,10 +103,41 @@ pub struct EpochClassificationV1 {
     pub notes: Vec<String>,
 
     // Config values from Config struct
-    pub config: Option<Value>,
+    pub config: Option<EpochConfig>,
 
     // General info about the Epoch
-    pub info: Option<Mapping>,
+    pub stats: Option<EpochStats>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct EpochStats {
+    pub bonus_stake_amount: Option<u64>,
+    pub min_epoch_credits: u64,
+    pub avg_epoch_credits: u64,
+    pub max_skip_rate: usize,
+    pub cluster_average_skip_rate: usize,
+    pub total_active_stake: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct EpochConfig {
+    pub require_classification: Option<bool>,
+    pub quality_block_producer_percentage: Option<usize>,
+    pub max_poor_block_producer_percentage: Option<usize>,
+    pub max_commission: Option<u8>,
+    pub min_release_version: Option<semver::Version>,
+    pub max_old_release_version_percentage: Option<usize>,
+    pub max_poor_voter_percentage: Option<usize>,
+    pub max_infrastructure_concentration: Option<f64>,
+    pub infrastructure_concentration_affects: Option<InfrastructureConcentrationAffects>,
+    pub bad_cluster_average_skip_rate: Option<usize>,
+    pub min_epoch_credit_percentage_of_average: Option<usize>,
+    pub min_self_stake_lamports: Option<u64>,
+    pub max_active_stake_lamports: Option<u64>,
+    pub enforce_min_self_stake: Option<bool>,
+    pub enforce_testnet_participation: Option<bool>,
+    pub min_testnet_participation: Option<(/*n:*/ usize, /*m:*/ usize)>,
+    pub baseline_stake_amount_lamports: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -4,7 +4,9 @@ use {
         generic_stake_pool::ValidatorStakeState,
     },
     log::*,
+    semver::Version,
     serde::{Deserialize, Serialize},
+    serde_yaml::{Mapping, Value},
     solana_sdk::{clock::Epoch, pubkey::Pubkey},
     std::{
         collections::HashMap,
@@ -43,6 +45,19 @@ pub struct ValidatorClassification {
 
     // The validator was not funded this epoch and should be prioritized next epoch
     pub prioritize_funding_in_next_epoch: Option<bool>,
+
+    pub blocks: Option<usize>,
+    pub slots: Option<usize>,
+
+    pub vote_credits: Option<u64>,
+    pub commission: Option<u8>,
+
+    pub self_stake: Option<u64>,
+
+    // Whether this is the first epoch the validator is a resident of current_data_center
+    pub new_data_center_residency: Option<bool>,
+
+    pub release_version: Option<Version>,
 }
 
 impl ValidatorClassification {
@@ -86,6 +101,12 @@ pub struct EpochClassificationV1 {
 
     // Informational notes regarding this epoch
     pub notes: Vec<String>,
+
+    // Config values from Config struct
+    pub config: Option<Value>,
+
+    // General info about the Epoch
+    pub info: Option<Mapping>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -111,7 +111,7 @@ pub struct EpochClassificationV1 {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct EpochStats {
-    pub bonus_stake_amount: Option<u64>,
+    pub bonus_stake_amount: u64,
     pub min_epoch_credits: u64,
     pub avg_epoch_credits: u64,
     pub max_skip_rate: usize,

--- a/bot/src/generic_stake_pool.rs
+++ b/bot/src/generic_stake_pool.rs
@@ -34,10 +34,19 @@ pub type ValidatorStakeActions = HashMap<Pubkey, String>;
 pub type UnfundedValidators = HashSet<Pubkey>;
 
 pub trait GenericStakePool {
+    /// Fourth value in returned tuple is the calculated bonus stake amount
     fn apply(
         &mut self,
         rpc_client: &RpcClient,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
-    ) -> Result<(EpochStakeNotes, ValidatorStakeActions, UnfundedValidators), Box<dyn error::Error>>;
+    ) -> Result<
+        (
+            EpochStakeNotes,
+            ValidatorStakeActions,
+            UnfundedValidators,
+            u64, // bonus stake amount
+        ),
+        Box<dyn error::Error>,
+    >;
 }

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1564,7 +1564,7 @@ fn classify(
     };
 
     let epoch_stats = EpochStats {
-        bonus_stake_amount: None,
+        bonus_stake_amount: 0,
         min_epoch_credits,
         avg_epoch_credits,
         max_skip_rate: (cluster_average_skip_rate + config.quality_block_producer_percentage),
@@ -1747,7 +1747,7 @@ fn main() -> BoxResult<()> {
         notifications.extend(validator_stake_change_notes);
 
         if let Some(ref mut stats) = epoch_classification.stats {
-            stats.bonus_stake_amount = Some(bonus_stake_amount);
+            stats.bonus_stake_amount = bonus_stake_amount;
         }
     }
 

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1941,8 +1941,15 @@ mod test {
         leader_schedule.insert(l3.to_string(), (20..30).collect());
         leader_schedule.insert(l4.to_string(), (30..40).collect());
         leader_schedule.insert(l5.to_string(), (40..50).collect());
-        let (quality, poor, _reason_msg, cluster_average_skip_rate, too_many_poor_block_producers) =
-            classify_producers(0, confirmed_blocks, leader_schedule, &config).unwrap();
+        let (
+            quality,
+            poor,
+            _reason_msg,
+            cluster_average_skip_rate,
+            too_many_poor_block_producers,
+            blocks_and_slots,
+        ) = classify_producers(0, confirmed_blocks, leader_schedule, &config).unwrap();
+
         assert_eq!(cluster_average_skip_rate, 58);
         assert!(quality.contains(&l1));
         assert!(quality.contains(&l5));
@@ -1952,6 +1959,15 @@ mod test {
         assert!(poor.contains(&l4));
         assert_eq!(poor.len(), 2);
         assert!(!too_many_poor_block_producers);
+
+        // spot-check that returned slots and blocks are correct
+        let l1_blocks_and_slots = blocks_and_slots.get(&l1).unwrap();
+        assert_eq!(l1_blocks_and_slots.0, 9);
+        assert_eq!(l1_blocks_and_slots.1, 10);
+
+        let l2_blocks_and_slots = blocks_and_slots.get(&l2).unwrap();
+        assert_eq!(l2_blocks_and_slots.0, 4);
+        assert_eq!(l2_blocks_and_slots.1, 10);
     }
 
     #[test]
@@ -1974,11 +1990,26 @@ mod test {
         leader_schedule.insert(l3.to_string(), (20..30).collect());
         leader_schedule.insert(l4.to_string(), (30..40).collect());
         leader_schedule.insert(l5.to_string(), (40..50).collect());
-        let (quality, poor, _reason_msg, cluster_average_skip_rate, too_many_poor_block_producers) =
-            classify_producers(0, confirmed_blocks, leader_schedule, &config).unwrap();
+        let (
+            quality,
+            poor,
+            _reason_msg,
+            cluster_average_skip_rate,
+            too_many_poor_block_producers,
+            blocks_and_slots,
+        ) = classify_producers(0, confirmed_blocks, leader_schedule, &config).unwrap();
         assert_eq!(cluster_average_skip_rate, 0);
         assert!(poor.is_empty());
         assert_eq!(quality.len(), 5);
         assert!(!too_many_poor_block_producers);
+
+        // spot-check that returned slots and blocks are correct
+        let l1_blocks_and_slots = blocks_and_slots.get(&l1).unwrap();
+        assert_eq!(l1_blocks_and_slots.0, 10);
+        assert_eq!(l1_blocks_and_slots.1, 10);
+
+        let l5_blocks_and_slots = blocks_and_slots.get(&l5).unwrap();
+        assert_eq!(l5_blocks_and_slots.0, 10);
+        assert_eq!(l5_blocks_and_slots.1, 10);
     }
 }

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -1,3 +1,4 @@
+use solana_sdk::pubkey::Pubkey;
 use {
     crate::generic_stake_pool::*,
     solana_client::rpc_client::RpcClient,
@@ -18,9 +19,26 @@ impl GenericStakePool for NoopStakePool {
         &mut self,
         _rpc_client: &RpcClient,
         _dry_run: bool,
-        _desired_validator_stake: &[ValidatorStake],
-    ) -> Result<(EpochStakeNotes, ValidatorStakeActions, UnfundedValidators), Box<dyn error::Error>>
-    {
-        Ok((vec![], HashMap::new(), HashSet::new()))
+        desired_validator_stake: &[ValidatorStake],
+    ) -> Result<
+        (
+            EpochStakeNotes,
+            ValidatorStakeActions,
+            UnfundedValidators,
+            u64,
+        ),
+        Box<dyn error::Error>,
+    > {
+        let validator_stake_actions: HashMap<Pubkey, String> = desired_validator_stake
+            .iter()
+            .map(|vs| {
+                (
+                    vs.identity,
+                    "Test action from NoopStakePool for validator".to_string(),
+                )
+            })
+            .collect();
+
+        Ok((vec![], validator_stake_actions, HashSet::new(), 12_345))
     }
 }

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -156,8 +156,15 @@ impl GenericStakePool for StakePoolOMatic {
         rpc_client: &RpcClient,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
-    ) -> Result<(EpochStakeNotes, ValidatorStakeActions, UnfundedValidators), Box<dyn error::Error>>
-    {
+    ) -> Result<
+        (
+            EpochStakeNotes,
+            ValidatorStakeActions,
+            UnfundedValidators,
+            u64,
+        ),
+        Box<dyn error::Error>,
+    > {
         let mut validator_stake_actions = HashMap::default();
         let mut no_stake_node_count = 0;
         let mut bonus_stake_node_count = 0;
@@ -343,7 +350,12 @@ impl GenericStakePool for StakePoolOMatic {
             &mut validator_stake_actions,
             &mut unfunded_validators,
         )?;
-        Ok((notes, validator_stake_actions, unfunded_validators))
+        Ok((
+            notes,
+            validator_stake_actions,
+            unfunded_validators,
+            bonus_stake_amount,
+        ))
     }
 }
 

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -97,8 +97,15 @@ impl GenericStakePool for StakePool {
         rpc_client: &RpcClient,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
-    ) -> Result<(EpochStakeNotes, ValidatorStakeActions, UnfundedValidators), Box<dyn error::Error>>
-    {
+    ) -> Result<
+        (
+            EpochStakeNotes,
+            ValidatorStakeActions,
+            UnfundedValidators,
+            u64,
+        ),
+        Box<dyn error::Error>,
+    > {
         let mut validator_stake_actions = HashMap::default();
 
         let mut inuse_stake_addresses = HashSet::default();
@@ -247,7 +254,12 @@ impl GenericStakePool for StakePool {
             &mut validator_stake_actions,
             &mut unfunded_validators,
         )?;
-        Ok((notes, validator_stake_actions, unfunded_validators))
+        Ok((
+            notes,
+            validator_stake_actions,
+            unfunded_validators,
+            bonus_stake_amount,
+        ))
     }
 }
 


### PR DESCRIPTION
So I decided to take a different approach to modifying the stake bot for the purposes of supporting the delegation program website. This PR just adds all the data we need to the yml files. There will be a separate program that is responsible for parsing those files and updating the database.

I tested as well as I could by using the NoopStakePool; this should definitely be run in "dryrun" mode with the real stake pools a few times to test that I didn't somehow break anything.