### PR TITLE
bot: Use TpuClient to send transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,19 @@ checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
  "console 0.14.1",
  "lazy_static",
- "number_prefix",
+ "number_prefix 0.3.0",
+ "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console 0.14.1",
+ "lazy_static",
+ "number_prefix 0.4.0",
  "regex",
 ]
 
@@ -2420,6 +2432,12 @@ name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -3753,7 +3771,7 @@ dependencies = [
  "bincode",
  "bs58 0.3.1",
  "clap",
- "indicatif",
+ "indicatif 0.15.0",
  "jsonrpc-core",
  "log 0.4.14",
  "net2",
@@ -3890,7 +3908,7 @@ checksum = "9f760066eeb645f504a049620493077a55c3228330a895a1207abdba53939f94"
 dependencies = [
  "bzip2",
  "console 0.14.1",
- "indicatif",
+ "indicatif 0.15.0",
  "log 0.4.14",
  "reqwest",
  "solana-runtime",
@@ -4473,7 +4491,7 @@ dependencies = [
  "borsh 0.9.0",
  "bs58 0.4.0",
  "clap",
- "indicatif",
+ "indicatif 0.16.2",
  "log 0.4.14",
  "regex",
  "reqwest",
@@ -4638,7 +4656,7 @@ dependencies = [
  "console 0.14.1",
  "core_affinity",
  "fd-lock",
- "indicatif",
+ "indicatif 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3.3"
 borsh = "0.9"
 bs58 = "0.4.0"
 clap = "2.33.0"
+indicatif = "0.16.2"
 log = "0.4.11"
 regex = "1.5.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["blocking", "rustls-tls", "json"] }
@@ -38,7 +39,6 @@ spl-token = "3.2"
 thiserror = "1.0.25"
 
 [dev-dependencies]
-indicatif = "0.15.0"
 solana-validator = "1.7.11"
 solana-vote-program = "1.7.11"
 

--- a/bot/src/generic_stake_pool.rs
+++ b/bot/src/generic_stake_pool.rs
@@ -5,6 +5,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         error,
+        sync::Arc,
     },
 };
 
@@ -37,7 +38,8 @@ pub trait GenericStakePool {
     /// Fourth value in returned tuple is the calculated bonus stake amount
     fn apply(
         &mut self,
-        rpc_client: &RpcClient,
+        rpc_client: Arc<RpcClient>,
+        websocket_url: &str,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -5,6 +5,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         error,
+        sync::Arc,
     },
 };
 
@@ -17,7 +18,8 @@ pub fn new() -> NoopStakePool {
 impl GenericStakePool for NoopStakePool {
     fn apply(
         &mut self,
-        _rpc_client: &RpcClient,
+        _rpc_client: Arc<RpcClient>,
+        _websocket_url: &str,
         _dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1226,10 +1226,10 @@ mod test {
                     .collect::<Vec<_>>(),
             )
             .unwrap();
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
 
         // ===========================================================
         info!("All validators to baseline");
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         uniform_stake_pool_apply(
             &mut stake_o_matic,
             rpc_client.clone(),
@@ -1242,6 +1242,7 @@ mod test {
 
         // ===========================================================
         info!("All the validators to bonus stake level");
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         uniform_stake_pool_apply(
             &mut stake_o_matic,
             rpc_client.clone(),
@@ -1254,6 +1255,7 @@ mod test {
 
         // ===========================================================
         info!("Different stake for each validator");
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         let desired_validator_stake = vec![
             ValidatorStake {
                 identity: validators[0].identity,
@@ -1348,13 +1350,14 @@ mod test {
 
         // ===========================================================
         info!("remove all validators");
-
         // deactivate all validator stake and remove from pool
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(rpc_client.clone(), websocket_url, false, &[])
             .unwrap();
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+
         // withdraw removed validator stake into the staker
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(rpc_client.clone(), websocket_url, false, &[])
             .unwrap();

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1099,7 +1099,7 @@ mod test {
 
         // ===========================================================
         info!("Start with adding validators and deposit stake, no managed stake yet");
-        let epoch = rpc_client.get_epoch_info().unwrap().epoch;
+        let epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(
                 rpc_client.clone(),

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1210,6 +1210,7 @@ mod test {
         .unwrap();
 
         info!("All validators to nothing, moving all to reserve");
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(
                 rpc_client.clone(),


### PR DESCRIPTION
Choose your own adventure! #163 or this.

#### Problem

Blockhashes expire too often while running the bot.

#### Solution

Use the TpuClient to send transactions instead of RpcClient.  This adapts the work from spl-token-cli to send and check transactions: https://github.com/solana-labs/solana-program-library/blob/21ae18dbd0458f9e5f18b1407a626670f6475438/token/cli/src/rpc_client_utils.rs#L36

There's a bit of churn to update parameters all over the place, but otherwise the code isn't too different.

I'll be running tests over the next couple of days to see this performs compared to the other PR, and I'll move it out of draft once the testing is complete.  If everything looks good, I'll probably opt for this.