### PR TITLE
bot: Add one more wait for slow CI to pass

### DIFF
--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1179,6 +1179,10 @@ mod test {
             )
             .unwrap();
 
+        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        stake_o_matic
+            .epoch_update(rpc_client.clone(), websocket_url)
+            .unwrap();
         info!("Deposit stake");
         let staker_pool_token_address = create_token_account(
             &rpc_client,


### PR DESCRIPTION
#### Problem

The TPU client is great, but does some extra waiting to check transactions.  The CI environment is slow, so sometimes the processing goes over the short epoch boundary in testing, causing the stake pool to require another update and fail.  That's annoying.

#### Solution

Add another wait to the stake pool test to get it to pass in a slower CI environment.