### PR TITLE
bot: Fix commitment used for transaction status check

### DIFF
--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -126,22 +126,20 @@ pub fn send_and_confirm_transactions_with_spinner(
                 last_resend = Instant::now();
             }
 
-            if !rpc_client.commitment().is_processed() {
-                // Wait for the next block before checking for transaction statuses
-                set_message(
-                    confirmed_transactions,
-                    Some(block_height),
-                    last_valid_block_height,
-                    &format!("Waiting for next block, {} pending...", num_transactions),
-                );
+            // Wait for the next block before checking for transaction statuses
+            set_message(
+                confirmed_transactions,
+                Some(block_height),
+                last_valid_block_height,
+                &format!("Waiting for next block, {} pending...", num_transactions),
+            );
 
-                let mut new_block_height = block_height;
-                while block_height == new_block_height {
-                    sleep(Duration::from_millis(500));
-                    new_block_height = rpc_client.get_block_height()?;
-                }
-                block_height = new_block_height;
+            let mut new_block_height = block_height;
+            while block_height == new_block_height {
+                sleep(Duration::from_millis(500));
+                new_block_height = rpc_client.get_block_height()?;
             }
+            block_height = new_block_height;
 
             if block_height > last_valid_block_height {
                 break;

--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -126,22 +126,24 @@ pub fn send_and_confirm_transactions_with_spinner(
                 last_resend = Instant::now();
             }
 
-            // Wait for the next block before checking for transaction statuses
-            set_message(
-                confirmed_transactions,
-                Some(block_height),
-                last_valid_block_height,
-                &format!("Waiting for next block, {} pending...", num_transactions),
-            );
+            if !rpc_client.commitment().is_processed() {
+                // Wait for the next block before checking for transaction statuses
+                set_message(
+                    confirmed_transactions,
+                    Some(block_height),
+                    last_valid_block_height,
+                    &format!("Waiting for next block, {} pending...", num_transactions),
+                );
 
-            let mut new_block_height = block_height;
-            while block_height == new_block_height {
-                sleep(Duration::from_millis(500));
-                new_block_height = rpc_client.get_block_height()?;
+                let mut new_block_height = block_height;
+                while block_height == new_block_height {
+                    sleep(Duration::from_millis(500));
+                    new_block_height = rpc_client.get_block_height()?;
+                }
+                block_height = new_block_height;
             }
-            block_height = new_block_height;
 
-            if new_block_height > last_valid_block_height {
+            if block_height > last_valid_block_height {
                 break;
             }
 

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -992,7 +992,7 @@ mod test {
         solana_logger::setup_with_default("solana_stake_o_matic=info");
 
         let mut test_validator_genesis = TestValidatorGenesis::default();
-        const TEST_SLOTS_PER_EPOCH: u64 = MINIMUM_SLOTS_PER_EPOCH * 3 / 2; // a bit longer than minimum to avoid CI failures
+        const TEST_SLOTS_PER_EPOCH: u64 = MINIMUM_SLOTS_PER_EPOCH * 2; // longer than minimum to avoid CI failures
         test_validator_genesis
             .epoch_schedule(EpochSchedule::custom(
                 TEST_SLOTS_PER_EPOCH,

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1099,7 +1099,7 @@ mod test {
 
         // ===========================================================
         info!("Start with adding validators and deposit stake, no managed stake yet");
-        let epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        let epoch = rpc_client.get_epoch_info().unwrap().epoch;
         stake_o_matic
             .apply(
                 rpc_client.clone(),
@@ -1210,7 +1210,6 @@ mod test {
         .unwrap();
 
         info!("All validators to nothing, moving all to reserve");
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(
                 rpc_client.clone(),
@@ -1242,8 +1241,7 @@ mod test {
         );
 
         // ===========================================================
-        info!("All the validators to bonus stake level");
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
+        info!("All validators to bonus stake level");
         uniform_stake_pool_apply(
             &mut stake_o_matic,
             rpc_client.clone(),
@@ -1256,7 +1254,6 @@ mod test {
 
         // ===========================================================
         info!("Different stake for each validator");
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         let desired_validator_stake = vec![
             ValidatorStake {
                 identity: validators[0].identity,
@@ -1352,7 +1349,6 @@ mod test {
         // ===========================================================
         info!("remove all validators");
         // deactivate all validator stake and remove from pool
-        let _epoch = wait_for_next_epoch(&rpc_client).unwrap();
         stake_o_matic
             .apply(rpc_client.clone(), websocket_url, false, &[])
             .unwrap();

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -474,7 +474,7 @@ fn withdraw_inactive_stakes_to_staker(
     .iter()
     .any(|err| err.is_some())
     {
-        Err("Failed to add validators to the stake pool".into())
+        Err("Failed to withdraw inactive stakes to the staker".into())
     } else {
         Ok(())
     }
@@ -633,7 +633,7 @@ fn remove_validators_from_pool(
     .iter()
     .any(|err| err.is_some())
     {
-        Err("Failed to add validators to the stake pool".into())
+        Err("Failed to remove validators from the stake pool".into())
     } else {
         Ok(())
     }
@@ -992,10 +992,11 @@ mod test {
         solana_logger::setup_with_default("solana_stake_o_matic=info");
 
         let mut test_validator_genesis = TestValidatorGenesis::default();
+        const TEST_SLOTS_PER_EPOCH: u64 = MINIMUM_SLOTS_PER_EPOCH * 3 / 2; // a bit longer than minimum to avoid CI failures
         test_validator_genesis
             .epoch_schedule(EpochSchedule::custom(
-                MINIMUM_SLOTS_PER_EPOCH,
-                MINIMUM_SLOTS_PER_EPOCH,
+                TEST_SLOTS_PER_EPOCH,
+                TEST_SLOTS_PER_EPOCH,
                 /* enable_warmup_epochs = */ false,
             ))
             .add_program("spl_stake_pool", spl_stake_pool::id());


### PR DESCRIPTION
#### Problem

When confirming transactions, the new `send_and_confirm` function was just using `Processed`, while the `RpcClient` was actually at finalized.  This caused an issue when calculating how much to distribute to validators *after* creating new validator stake accounts.  When fetching the reserve stake balance, we were getting the `Finalized` balance, which was higher than the `Processed` one post-creation of new validator stake accounts.

This succeeded on the second run because we didn't create any new validator stake accounts, so the reserve balance didn't change in the middle of the run.  This means the distribution calculation was done properly the second time.

Fun fact, I found this by checking the failing transaction, and noticing that it was exactly off by 44 SOL, which seemed suspicious.  In the first run, we added 45 new validators, which took out 45 SOL out of the reserve.  Most likely one of the transactions got finalized before we refetched the reserve balance.

#### Solution

All this to say: use the commitment from the RPC client to check transaction statuses.