### PR TITLE
bot: Use correct minimum for stake decreases

### DIFF
--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -783,7 +783,7 @@ where
         #[allow(clippy::comparison_chain)]
         let op_msg = if balance > desired_balance {
             let amount_to_remove = balance - desired_balance;
-            if amount_to_remove < MIN_STAKE_CHANGE_AMOUNT {
+            if amount_to_remove < stake_rent_exemption {
                 format!("not removing {} (amount too small)", Sol(amount_to_remove))
             } else {
                 transactions.push(Transaction::new_with_payer(


### PR DESCRIPTION
#### Problem

There was a failure in the stake pool job before testnet went down because the wrong minimum stake amount was used for decreasing stake.  With the update to 0.5.0, the minimum for a validator stake account went from 1 SOL + rent exemption to 0.001 SOL + rent exemption.  When decreasing, we were only checking that it was >= to the minimum (0.001 SOL), which isn't enough to split a new stake account, since that requires rent exemption.

#### Solution

All this to say, require that decreases be at least the rent exemption for a stake account.  Increases are OK because they can be increased by 0.001, the rent-exemption is done internally.