### PR TITLE
bot: Handle empty transaction situations better

### DIFF
--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -74,6 +74,9 @@ pub fn send_and_confirm_transactions_with_spinner(
     transactions: Vec<Transaction>,
     signer: &Keypair,
 ) -> Result<Vec<Option<TransactionError>>, Box<dyn error::Error>> {
+    if transactions.is_empty() {
+        return Ok(vec![]);
+    }
     let progress_bar = new_spinner_progress_bar();
     let mut expired_blockhash_retries = 5;
     let send_transaction_interval = Duration::from_millis(10); /* Send at ~100 TPS */

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -492,6 +492,11 @@ fn update_stake_pool(
     stake_pool: &StakePool,
     validator_list: &ValidatorList,
 ) -> Result<(), Box<dyn error::Error>> {
+    let epoch_info = rpc_client.get_epoch_info()?;
+    if stake_pool.last_update_epoch == epoch_info.epoch {
+        println!("Stake pool up to date, no need to update");
+        return Ok(());
+    }
     let (update_list_instructions, final_instructions) =
         spl_stake_pool::instruction::update_stake_pool(
             &spl_stake_pool::id(),


### PR DESCRIPTION
#### Problem

The mainnet stake pool run started hanging on an empty set of transactions.  That's kind of silly, especially when there was no need to be there in the first place (the stake pool was already up to date).

#### Solution

Sending an empty set of transactions actually succeeds, but there's no reason to do any work if there aren't any transactions to send.

Also, don't update the stake pool if it's already up to date.