### PR TITLE
bot: Reduce testnet participation for stake pool through flag

### DIFF
--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -13,6 +13,12 @@ else
   EPOCH_CLASSIFICATION="--epoch-classification first"
 fi
 
+if [[ -n $SHORT_TESTNET_PARTICIPATION ]]; then
+  TESTNET_PARTICIPATION="--min-testnet-participation 2 4"
+else
+  TESTNET_PARTICIPATION="--min-testnet-participation 5 10"
+fi
+
 if [[ ! -d db ]]; then
   git clone git@github.com:solana-labs/stake-o-matic.wiki.git db
 fi
@@ -43,7 +49,7 @@ MAINNET_BETA_ARGS=(
   --max-infrastructure-concentration 10
   --infrastructure-concentration-affects destake-new
   --min-self-stake 100
-  --min-testnet-participation 5 10
+  $TESTNET_PARTICIPATION
   --enforce-testnet-participation
   --enforce-min-self-stake
 )


### PR DESCRIPTION
#### Problem

The mainnet stake pool job is classifying most validators as "poor" because of low testnet participation.  Unfortunately, there just isn't that much data.

#### Solution

Lower the number of required epochs to 2 out of 4, since we only have 4 pushed currently.