### PR TITLE
New commission calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
  "bincode",
  "borsh 0.9.0",
  "bs58 0.4.0",
+ "chrono",
  "clap",
  "indicatif 0.16.2",
  "log 0.4.14",

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 bincode = "1.3.3"
 borsh = "0.9"
 bs58 = "0.4.0"
+chrono = "0.4.19"
 clap = "2.33.0"
 indicatif = "0.16.2"
 log = "0.4.11"

--- a/bot/src/data_center_info.rs
+++ b/bot/src/data_center_info.rs
@@ -1,3 +1,4 @@
+use crate::Cluster;
 use {
     crate::validators_app,
     log::*,
@@ -78,16 +79,9 @@ pub struct DataCenters {
     pub by_identity: HashMap<Pubkey, DataCenterId>,
 }
 
-pub fn get(cluster: &str) -> Result<DataCenters, Box<dyn error::Error>> {
-    let cluster_json = match cluster {
-        "mainnet-beta" => validators_app::ClusterJson::MainnetBeta,
-        "testnet" => validators_app::ClusterJson::Testnet,
-        _ => return Err(format!("Unsupported cluster: {}", cluster).into()),
-    };
+pub fn get(cluster: Cluster) -> Result<DataCenters, Box<dyn error::Error>> {
+    let client = validators_app::Client::new_with_cluster(cluster)?;
 
-    let token = std::env::var("VALIDATORS_APP_TOKEN")
-        .map_err(|err| format!("VALIDATORS_APP_TOKEN: {}", err))?;
-    let client = validators_app::Client::new(token, cluster_json);
     let validators = client.validators(None, None)?;
     let mut data_center_map = HashMap::new();
     let mut total_stake = 0;

--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -58,6 +58,10 @@ pub struct ValidatorClassification {
     pub new_data_center_residency: Option<bool>,
 
     pub release_version: Option<Version>,
+
+    // The number of times the validator has exceeded the max commission
+    // Note we only started counting this around Jan 2022; epochs prior to Jan 2022 are not counted
+    pub num_epochs_max_commission_exceeded: Option<u8>,
 }
 
 impl ValidatorClassification {

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -2180,7 +2180,7 @@ mod test {
             CommissionChangeIndexHistoryEntry {
                 commission_before: None,
                 commission_after: 10.0,
-                epoch: epoch,
+                epoch,
                 epoch_completion: 10.0,
                 ..Default::default()
             },
@@ -2188,7 +2188,7 @@ mod test {
             CommissionChangeIndexHistoryEntry {
                 commission_before: Some(10.0),
                 commission_after: expected_commission,
-                epoch: epoch,
+                epoch,
                 epoch_completion: 90.0,
                 ..Default::default()
             },
@@ -2241,7 +2241,7 @@ mod test {
         let history = [CommissionChangeIndexHistoryEntry {
             commission_before: Some(0.0),
             commission_after: expected_commission,
-            epoch: epoch,
+            epoch,
             epoch_completion: 50.0,
             ..Default::default()
         }]

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -41,6 +41,8 @@ impl GenericStakePool for NoopStakePool {
             })
             .collect();
 
-        Ok((vec![], validator_stake_actions, HashSet::new(), 12_345))
+        let notes = vec!["This is the noop stake pool. All number are make-believe.".to_string()];
+
+        Ok((notes, validator_stake_actions, HashSet::new(), 12_345))
     }
 }

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -108,10 +108,10 @@ pub fn new(
     Ok(StakePoolOMatic {
         authorized_staker,
         baseline_stake_amount,
+        min_reserve_stake_balance,
         stake_pool_address,
         stake_pool,
         validator_list,
-        min_reserve_stake_balance,
     })
 }
 

--- a/bot/src/validators_app.rs
+++ b/bot/src/validators_app.rs
@@ -197,7 +197,7 @@ pub struct Client {
     client: reqwest::blocking::Client,
 }
 
-pub fn get_validators_app_token() -> Result<String, String> {
+pub fn get_validators_app_token_from_env() -> Result<String, String> {
     std::env::var("VALIDATORS_APP_TOKEN").map_err(|err| format!("VALIDATORS_APP_TOKEN: {}", err))
 }
 
@@ -212,7 +212,7 @@ impl Client {
     }
 
     pub fn new_with_cluster(cluster: Cluster) -> Result<Self, Box<dyn error::Error>> {
-        let token = get_validators_app_token()?;
+        let token = get_validators_app_token_from_env()?;
         let client = Self::new(token, ClusterJson::from_cluster(cluster));
 
         Ok(client)


### PR DESCRIPTION
Update bot to use the commission at the end of epoch

Previously, for the purposes of determining whether a validator met the max commission requirement, we used the validator's commission at the time the stake bot run. This made it so that validators could raise their commission immediately before an epoch ended, and then lower it immediately after the next epoch started, thus effectively having a high commission rate while still being in good standing with the program. This commit uses the validators.app commission-changes endpoint to determine what a validator's commission was when the epoch ended, and uses that value for determining if the validator was above the max allowed commission rate.

In addition, validators that have a commission above the max allowed for more than one epoch will be permanently destaked. A future PR will make it so that such validators are removed from the program.
