### PR TITLE
bot: Add participant URL parameter

### DIFF
--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -26,6 +26,7 @@ fi
 # shellcheck disable=SC2206
 TESTNET_ARGS=(
   --url ${URL:?}
+  --participant-url ${PARTICIPANT_URL:?}
   --cluster testnet
   --quality-block-producer-percentage 30
   --max-poor-block-producer-percentage 20
@@ -39,6 +40,7 @@ TESTNET_ARGS=(
 # shellcheck disable=SC2206
 MAINNET_BETA_ARGS=(
   --url ${URL:?}
+  --participant-url ${URL:?}
   --cluster mainnet-beta
   --quality-block-producer-percentage 30
   --max-poor-block-producer-percentage 20


### PR DESCRIPTION
#### Problem

The participants are loaded from a hardcoded string of "https://api.mainnet-beta.solana.com", which is an issue if the endpoint is ever down.

#### Solution

Allow this URL to be configured on the command-line.

Note that it looks like a copy-pasta error on stake-o-matic.sh, but it's intentional -- the participant url doesn't need to be configured on mainnet since it'll just load it from the same url.