### PR TITLE
Fix bot to properly calculate testnet participation

### DIFF
--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -18,7 +18,8 @@ use {
 
 #[derive(Default, Clone, Deserialize, Serialize)]
 pub struct ValidatorClassification {
-    pub identity: Pubkey, // Validator identity
+    pub identity: Pubkey,
+    // Validator identity
     pub vote_address: Pubkey,
 
     pub stake_state: ValidatorStakeState,
@@ -62,23 +63,6 @@ pub struct ValidatorClassification {
     // The number of times the validator has exceeded the max commission
     // Note we only started counting this around Jan 2022; epochs prior to Jan 2022 are not counted
     pub num_epochs_max_commission_exceeded: Option<u8>,
-}
-
-impl ValidatorClassification {
-    // Was the validator staked for at last `n` of the last `m` epochs?
-    pub fn staked_for(&self, n: usize, m: usize) -> bool {
-        self.stake_states
-            .as_ref()
-            .map(|stake_states| {
-                stake_states
-                    .iter()
-                    .take(m)
-                    .filter(|(stake_state, _)| *stake_state != ValidatorStakeState::None)
-                    .count()
-                    >= n
-            })
-            .unwrap_or_default()
-    }
 }
 
 pub type ValidatorClassificationByIdentity =
@@ -197,12 +181,9 @@ impl EpochClassification {
 
             if Self::exists(previous_epoch, &path) {
                 let previous_epoch_classification =
-                    Self::load(previous_epoch, &path)?.into_current();
+                    Self::load_if_validators_classified(previous_epoch, &path)?;
 
-                if previous_epoch_classification
-                    .validator_classifications
-                    .is_some()
-                {
+                if let Some(epoch_classification) = previous_epoch_classification {
                     info!(
                         "Previous EpochClassification found for epoch {} at {}",
                         previous_epoch,
@@ -210,7 +191,7 @@ impl EpochClassification {
                     );
                     return Ok(Some((
                         previous_epoch,
-                        Self::V1(previous_epoch_classification),
+                        Self::V1(epoch_classification.into_current()),
                     )));
                 } else {
                     info!(
@@ -222,36 +203,23 @@ impl EpochClassification {
         }
     }
 
-    // Loads the latest epoch that contains `Some(validator_classifications)`
-    // Returns `Ok(None)` if no epoch is available
-    pub fn load_latest<P>(path: P) -> Result<Option<(Epoch, Self)>, io::Error>
+    // Returns the EpochClassification for `epoch` at `path` if it exists and if it contains validator_classifications
+    // (that is, if stake was adjusted for validators for the epoch)
+    pub fn load_if_validators_classified<P>(
+        epoch: Epoch,
+        path: P,
+    ) -> Result<Option<Self>, io::Error>
     where
-        P: AsRef<Path>,
+        P: AsRef<Path> + Copy,
     {
-        let epoch_filename_regex = regex::Regex::new(r"^epoch-(\d+).yml$").unwrap();
+        if Self::exists(epoch, path) {
+            let epoch_classification = Self::load(epoch, &path)?.into_current();
 
-        let mut epochs = vec![];
-        if let Ok(entries) = fs::read_dir(&path) {
-            for entry in entries.filter_map(|entry| entry.ok()) {
-                if entry.path().is_file() {
-                    let filename = entry
-                        .file_name()
-                        .into_string()
-                        .unwrap_or_else(|_| String::new());
-
-                    if let Some(captures) = epoch_filename_regex.captures(&filename) {
-                        epochs.push(captures.get(1).unwrap().as_str().parse::<u64>().unwrap());
-                    }
-                }
+            if epoch_classification.validator_classifications.is_some() {
+                return Ok(Some(Self::V1(epoch_classification)));
             }
         }
-        epochs.sort_unstable();
-
-        if let Some(latest_epoch) = epochs.last() {
-            Self::load_previous(*latest_epoch + 1, path)
-        } else {
-            Ok(None)
-        }
+        Ok(None)
     }
 
     pub fn save<P>(&self, epoch: Epoch, path: P) -> Result<(), io::Error>
@@ -266,27 +234,5 @@ impl EpochClassification {
         file.write_all(&serialized.into_bytes())?;
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_staked_for() {
-        let mut vc = ValidatorClassification::default();
-
-        assert!(!vc.staked_for(0, 0));
-        assert!(!vc.staked_for(1, 0));
-        assert!(!vc.staked_for(0, 1));
-
-        vc.stake_states = Some(vec![
-            (ValidatorStakeState::None, String::new()),
-            (ValidatorStakeState::Baseline, String::new()),
-            (ValidatorStakeState::Bonus, String::new()),
-        ]);
-        assert!(!vc.staked_for(3, 3));
-        assert!(vc.staked_for(2, 3));
     }
 }


### PR DESCRIPTION
Previously some validators were receiving stake even though their testnet validators were no longer running.

The cause of the problem was that we were determining if a validator had bonus or baseline in n of the last m epochs by just looking at the last m epochs found in ValidatorClassification.stake_states, but if the validator had been shut down there would be no records for those epochs, and so the validator would not be penalized.

The fix is to look in the epoch-NNN.yml files for each of the last m epochs to determine the performance of validators.