### PR TITLE
Update rules for permanently destaking for high commission

### DIFF
--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -62,6 +62,11 @@ pub struct ValidatorClassification {
     // The number of times the validator has exceeded the max commission
     // Note we only started counting this around Jan 2022; epochs prior to Jan 2022 are not counted
     pub num_epochs_max_commission_exceeded: Option<u8>,
+
+    // The number of times the validator was below max_commission at the end of one epoch, then above max_commission at
+    // the end of a subsequent epoch
+    // Note that we only started counting this around April/May 2022
+    pub num_epochs_commission_increased_above_max: Option<u8>,
 }
 
 impl ValidatorClassification {

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1416,7 +1416,8 @@ fn classify(
                     0
                 });
 
-            // if the commission was below max_commission last epoch, and is above max_commission this epoch
+            // if the commission was below max_commission at the beginning of the last epoch, and is
+            // above max_commission at the beginning of the current epoch
             let commission_increased_above_max = commission_at_end_of_epoch > config.max_commission
                 && previous_classification
                     .and_then(|pc| pc.commission)


### PR DESCRIPTION
Validators will now be permanently destaked if they have more than once been below max_commission at the end of one epoch, and above max_commission at the end of a subsequent epoch.

Previously we permanently destaked validators who were above max_commission for more than one epoch. This caused some validators to get permanently destaked just for failing to pay attention for a few epochs.

@t-nelson 