### PR TITLE
Pin Rust version to 1.60.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.60.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.60.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This should prevent unpredictable CI results caused by the CI engine
always using the latest Rust version