### PR TITLE
Disable require-performance-metric-reporting for mainnet

### DIFF
--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -63,7 +63,6 @@ MAINNET_BETA_ARGS=(
   --min-self-stake-exceptions-key ${SELF_STAKE_EXCEPTIONS_KEY:?}
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
-  --require-performance-metrics-reporting
 )
 
 # shellcheck disable=SC2206


### PR DESCRIPTION
Currently there is a bug in how this metric is applied for mainnet.

@c3pko 