### PR TITLE
Bot: Fix issue where the wrong epoch was being looked at when looking…

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -2169,7 +2169,7 @@ fn main() -> BoxResult<()> {
     };
 
     let epoch = rpc_client.get_epoch_info()?.epoch;
-    info!("Epoch: {:?}", epoch);
+    info!("Current epoch: {:?}", epoch);
     if epoch == 0 {
         return Ok(());
     }

--- a/bot/src/performance_db_utils.rs
+++ b/bot/src/performance_db_utils.rs
@@ -138,7 +138,7 @@ fn find_reporters_for_epoch(
     // and 75%, and if the validator reported correctly during any one  of the sample periodsd, the validator passes.
     for n in 0..4 {
         let slot_to_try: i64 = match cluster {
-            MainnetBeta => (DEFAULT_SLOTS_PER_EPOCH as i64) * ((*epoch - 1) as i64),
+            MainnetBeta => (DEFAULT_SLOTS_PER_EPOCH as i64) * (*epoch as i64),
             // Testnet epoch boundaries aren't on multiples of DEFAULT_SLOTS_PER_EPOCH for some reason
             // Epoch 341 starts at slot 141788256; use that as our anchor.
             // Testnet => (141_788_256 as u64).wrapping_add( DEFAULT_SLOTS_PER_EPOCH.wrapping_mul((341 as u64).wrapping_sub(*epoch)))

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -63,6 +63,7 @@ MAINNET_BETA_ARGS=(
   --min-self-stake-exceptions-key ${SELF_STAKE_EXCEPTIONS_KEY:?}
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
+  --require-performance-metrics-reporting
 )
 
 # shellcheck disable=SC2206


### PR DESCRIPTION
… for reporting data

When processing mainnet epochs, the bot was looking for reporting in the epoch previous to the one it should have been looking at. So e.g., when it should have been looking for reporting in epoch 332, it was looking at epoch 331.

@c3pko 