### PR TITLE
bot: Increase testnet min stake

### DIFF
--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -40,6 +40,7 @@ TESTNET_ARGS=(
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
   --require-performance-metrics-reporting
+  --min-reserve-stake-balance 2.00456576
 )
 
 # shellcheck disable=SC2206


### PR DESCRIPTION
This is a temporary fix while we figure out why the bot is causing InsufficientDelegation errors to be thrown