### PR TITLE
bot: Log failed transaction signatures for investigation

### DIFF
--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -193,8 +193,10 @@ pub fn send_and_confirm_transactions_with_spinner(
                                 if let Some((i, _)) = pending_transactions.remove(signature) {
                                     confirmed_transactions += 1;
                                     if status.err.is_some() {
-                                        progress_bar
-                                            .println(format!("Failed transaction: {:?}", status));
+                                        progress_bar.println(format!(
+                                            "Failed transaction {}: {:?}",
+                                            signature, status
+                                        ));
                                     }
                                     transaction_errors[i] = status.err;
                                 }


### PR DESCRIPTION
#### Problem

Failed transactions only give the error, which can make it hard to learn more about the issue.

#### Solution

Also log the transaction signature, so we can investigate the exact error and accounts involved in an explorer.