### PR TITLE
bot: Minor change to how self-reporting metrics are collected

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -1447,14 +1447,24 @@ fn classify(
             if let (Some(performance_db_url), Some(performance_db_token)) =
                 (&config.performance_db_url, &config.performance_db_token)
             {
-                Some(get_reported_performance_metrics(
+                let reported_performance_metrics = get_reported_performance_metrics(
                     performance_db_url,
                     performance_db_token,
                     &config.cluster,
                     rpc_client,
                     &(epoch - 1),
                     &all_participants,
-                )?)
+                );
+
+                if let Ok(metrics) = reported_performance_metrics {
+                    Some(metrics)
+                } else {
+                    info!(
+                        "Could not get reported performance metrics: {:?}",
+                        reported_performance_metrics.err().unwrap()
+                    );
+                    None
+                }
             } else {
                 None
             };
@@ -1468,8 +1478,6 @@ fn classify(
             });
             number_sampled_epochs = 1;
         };
-
-        debug!("reporting_counts: {:?}", reporting_counts);
 
         let mut number_loops = 0;
 

--- a/bot/src/performance_db_utils.rs
+++ b/bot/src/performance_db_utils.rs
@@ -2,7 +2,7 @@ use crate::Cluster::{MainnetBeta, Testnet};
 use crate::{Cluster, Epoch, Pubkey, ValidatorList};
 use chrono::{DateTime, Duration as ChronoDuration, NaiveDateTime, Utc};
 use itertools::Itertools;
-use log::{debug, trace};
+use log::{debug, info, trace};
 use solana_client::client_error::ClientErrorKind;
 use solana_client::rpc_client::RpcClient;
 use solana_foundation_delegation_program_registry::state::Participant;
@@ -157,6 +157,11 @@ fn find_reporters_for_epoch(
 
         let reported_data =
             fetch_data(performance_db_url, performance_db_token, cluster, slot_time)?;
+
+        if reported_data.is_empty() {
+            info!("No records found for time {:?}", slot_time);
+            continue;
+        }
 
         let optimistic_slot_modes = get_modes(reported_data.values().cloned().collect());
         let min_optimistic_slot = optimistic_slot_modes


### PR DESCRIPTION
If no records are found in one of the self-reporting samples, continue rather than end; only require that at least one sample has records.

Also small improvements to logged messages.